### PR TITLE
cache build stages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 # each stage does its own yarn install
-node_modules
+**/node_modules/
+**/.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
         # The .ts scripts depend upon this
       - run: npm install --global tsx
 
-      - name: Export vars of Actions Runtime for caching
-        uses: crazy-max/ghaction-github-runtime@v3
-
       - name: build use images
         run: ./buildUseImages.ts
 
@@ -83,9 +80,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # use GitHub Actions Cache https://github.com/moby/buildkit#github-actions-cache-experimental
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+          cache-to: type=inline
 
       - name: notify on failure
         if: failure() && github.event_name != 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
 
       - name: build test images
-        run: ./buildTestImages.ts --buildOpts="--cache-from type=gha --cache-to type=gha,mode=max"
+        run: ./buildTestImages.ts
 
       - name: run test images
         run: ./runTestImages.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Export vars of Actions Runtime for caching
         uses: crazy-max/ghaction-github-runtime@v3
 
+      - name: build use images
+        run: ./buildUseImages.ts
+
       - name: build test images
         run: ./buildTestImages.ts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,12 @@ jobs:
         # The .ts scripts depend upon this
       - run: npm install --global tsx
 
+      - name: Export vars of Actions Runtime for caching
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: build test images
-        run: |
-          docker info
-          ./buildTestImages.ts
+        run: ./buildTestImages.ts --buildOpts="--cache-from type=gha --cache-to type=gha,mode=max"
+
       - name: run test images
         run: ./runTestImages.ts
 
@@ -78,6 +80,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # use GitHub Actions Cache https://github.com/moby/buildkit#github-actions-cache-experimental
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: notify on failure
         if: failure() && github.event_name != 'pull_request'
         uses: ./.github/actions/notify-status

--- a/buildTestImages.ts
+++ b/buildTestImages.ts
@@ -8,12 +8,13 @@ import { refreshDockerfile } from './makeDockerfile';
 refreshDockerfile();
 
 const options = {
+  buildOpts: { type: 'string' },
   match: { short: 'm', type: 'string' },
   dry: { type: 'boolean' },
 } as const;
 const { values } = parseArgs({ options });
 
-const { match, dry } = values;
+const { buildOpts, match, dry } = values;
 
 const allProposals = readProposals();
 
@@ -28,7 +29,7 @@ for (const proposal of proposals) {
   const { name, target } = imageNameForProposalTest(proposal);
   // 'load' to ensure the images are output to the Docker client. Seems to be necessary
   // for the CI docker/build-push-action to re-use the cached stages.
-  const cmd = `docker buildx build --load --tag ${name} --target ${target} .`;
+  const cmd = `docker buildx build ${buildOpts} --load --tag ${name} --target ${target} .`;
   console.log(cmd);
   if (!dry) {
     execSync(cmd, { stdio: 'inherit' });

--- a/buildTestImages.ts
+++ b/buildTestImages.ts
@@ -21,24 +21,14 @@ const proposals = match
   ? allProposals.filter(p => p.proposalName.includes(match))
   : allProposals;
 
-function buildOptsFor(name: string) {
-  // use GitHub Actions Cache if enabled https://docs.docker.com/build/cache/backends/gha/
-  if (process.env.ACTIONS_RUNTIME_TOKEN) {
-    const refName = process.env.GITHUB_REF_NAME;
-    return `--cache-from type=gha,scope=${refName}-${name} --cache-to type=gha,mode=max,scope=${refName}-${name}`;
-  }
-  return '';
-}
-
 for (const proposal of proposals) {
   if (!dry) {
     console.log(`\nBuilding test image for proposal ${proposal.proposalName}`);
   }
   const { name, target } = imageNameForProposal(proposal, 'test');
-  const opts = buildOptsFor(name);
   // 'load' to ensure the images are output to the Docker client. Seems to be necessary
   // for the CI docker/build-push-action to re-use the cached stages.
-  const cmd = `docker buildx build ${opts} --load --tag ${name} --target ${target} .`;
+  const cmd = `docker buildx build --load --tag ${name} --target ${target} .`;
   console.log(cmd);
   if (!dry) {
     execSync(cmd, { stdio: 'inherit' });

--- a/buildTestImages.ts
+++ b/buildTestImages.ts
@@ -8,13 +8,12 @@ import { refreshDockerfile } from './makeDockerfile';
 refreshDockerfile();
 
 const options = {
-  buildOpts: { type: 'string' },
   match: { short: 'm', type: 'string' },
   dry: { type: 'boolean' },
 } as const;
 const { values } = parseArgs({ options });
 
-const { buildOpts, match, dry } = values;
+const { match, dry } = values;
 
 const allProposals = readProposals();
 
@@ -22,14 +21,24 @@ const proposals = match
   ? allProposals.filter(p => p.proposalName.includes(match))
   : allProposals;
 
+function buildOptsFor(name: string) {
+  // use GitHub Actions Cache if enabled https://docs.docker.com/build/cache/backends/gha/
+  if (process.env.ACTIONS_RUNTIME_TOKEN) {
+    const refName = process.env.GITHUB_REF_NAME;
+    return `--cache-from type=gha,scope=${refName}-${name} --cache-to type=gha,mode=max,scope=${refName}-${name}`;
+  }
+  return '';
+}
+
 for (const proposal of proposals) {
   if (!dry) {
     console.log(`\nBuilding test image for proposal ${proposal.proposalName}`);
   }
   const { name, target } = imageNameForProposalTest(proposal);
+  const opts = buildOptsFor(name);
   // 'load' to ensure the images are output to the Docker client. Seems to be necessary
   // for the CI docker/build-push-action to re-use the cached stages.
-  const cmd = `docker buildx build ${buildOpts} --load --tag ${name} --target ${target} .`;
+  const cmd = `docker buildx build ${opts} --load --tag ${name} --target ${target} .`;
   console.log(cmd);
   if (!dry) {
     execSync(cmd, { stdio: 'inherit' });

--- a/buildUseImages.ts
+++ b/buildUseImages.ts
@@ -21,24 +21,14 @@ const proposals = match
   ? allProposals.filter(p => p.proposalName.includes(match))
   : allProposals;
 
-function buildOptsFor(name: string) {
-  // use GitHub Actions Cache if enabled https://docs.docker.com/build/cache/backends/gha/
-  if (process.env.ACTIONS_RUNTIME_TOKEN) {
-    const refName = process.env.GITHUB_REF_NAME;
-    return `--cache-from type=gha,scope=${refName}-${name} --cache-to type=gha,mode=max,scope=${refName}-${name}`;
-  }
-  return '';
-}
-
 for (const proposal of proposals) {
   if (!dry) {
-    console.log(`\nBuilding test image for proposal ${proposal.proposalName}`);
+    console.log(`\nBuilding use image for proposal ${proposal.proposalName}`);
   }
-  const { name, target } = imageNameForProposal(proposal, 'test');
-  const opts = buildOptsFor(name);
+  const { name, target } = imageNameForProposal(proposal, 'use');
   // 'load' to ensure the images are output to the Docker client. Seems to be necessary
   // for the CI docker/build-push-action to re-use the cached stages.
-  const cmd = `docker buildx build ${opts} --load --tag ${name} --target ${target} .`;
+  const cmd = `docker buildx build --load --tag ${name} --target ${target} .`;
   console.log(cmd);
   if (!dry) {
     execSync(cmd, { stdio: 'inherit' });

--- a/common.ts
+++ b/common.ts
@@ -44,8 +44,11 @@ export function readProposals(): ProposalInfo[] {
   return proposalPaths.map(readInfo);
 }
 
-export function imageNameForProposalTest(proposal) {
-  const target = `test-${proposal.proposalName}`;
+export function imageNameForProposal(
+  proposal: ProposalCommon,
+  stage: 'use' | 'test',
+) {
+  const target = `${stage}-${proposal.proposalName}`;
   return {
     name: `${repository}:${target}`,
     target,

--- a/runTestImages.ts
+++ b/runTestImages.ts
@@ -2,7 +2,7 @@
 
 import { parseArgs } from 'node:util';
 import { execSync } from 'node:child_process';
-import { imageNameForProposalTest, readProposals } from './common';
+import { imageNameForProposal, readProposals } from './common';
 
 const options = {
   match: { short: 'm', type: 'string' },
@@ -19,7 +19,7 @@ const proposals = match
 
 for (const proposal of proposals) {
   console.log(`Running test image for proposal ${proposal.proposalName}`);
-  const { name } = imageNameForProposalTest(proposal);
+  const { name } = imageNameForProposal(proposal, 'test');
   // 'rm' to remove the container when it exits
   const cmd = `docker run --rm ${name}`;
   execSync(cmd, { stdio: 'inherit' });

--- a/upgrade-test-scripts/run_eval.sh
+++ b/upgrade-test-scripts/run_eval.sh
@@ -6,8 +6,6 @@ set -e
 
 source ./env_setup.sh
 
-export SLOGFILE=slog.slog
-
 PROPOSAL_PATH=$1
 
 startAgd

--- a/upgrade-test-scripts/run_test.sh
+++ b/upgrade-test-scripts/run_test.sh
@@ -6,8 +6,6 @@ set -e
 
 source ./env_setup.sh
 
-export SLOGFILE=slog.slog
-
 PROPOSAL_PATH=$1
 
 startAgd

--- a/upgrade-test-scripts/run_use.sh
+++ b/upgrade-test-scripts/run_use.sh
@@ -23,8 +23,6 @@ fi
 
 source ./env_setup.sh
 
-export SLOGFILE=slog.slog
-
 echo "Starting agd in the background."
 startAgd
 

--- a/upgrade-test-scripts/start_agd.sh
+++ b/upgrade-test-scripts/start_agd.sh
@@ -6,7 +6,5 @@ grep -qF 'printKeys' /root/.bashrc || echo "printKeys" >>/root/.bashrc
 
 source ./env_setup.sh
 
-export SLOGFILE=slog.slog
-
 # don't use startAgd() because that backgrounds
 agd start --log_level warn "$@"

--- a/upgrade-test-scripts/start_to_to.sh
+++ b/upgrade-test-scripts/start_to_to.sh
@@ -6,8 +6,6 @@ grep -qF 'printKeys' /root/.bashrc || echo "printKeys" >>/root/.bashrc
 
 source ./env_setup.sh
 
-export SLOGFILE=slog.slog
-
 startAgd
 
 if [[ -z "${UPGRADE_TO}" ]]; then


### PR DESCRIPTION
**Before**

https://github.com/Agoric/agoric-3-proposals/actions/runs/6775971345/job/18416450836

| Job | Time
| -- | --
| build test images | 49.8 min
| run test images | 2.5 min
| Build and push complete image | 0.5 min


**After**
https://github.com/Agoric/agoric-3-proposals/actions/runs/6776139160/job/18416966447

| Job | Time
| -- | --
| build test images | 59.5 min
| run test images | 3.9 min
| Build and push complete image | 0.8 min

Slower across the board. I don't know if it's just CI weather or the caching IO slowed things down. It's definitely being written to!

```
❯ gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/agoric/agoric-3-proposals/actions/cache/usage
{
  "full_name": "Agoric/agoric-3-proposals",
  "active_caches_size_in_bytes": 19244682819,
  "active_caches_count": 349
}
```

**Second run with caching enabled**

https://github.com/Agoric/agoric-3-proposals/actions/runs/6776896609/job/18419392914

Sadly, it's still running `start_to_to.sh`. I think the solution may require explicit cache management and invalidation. E.g. don't re-build tests that haven't been touched.