### PR TITLE
ci(docker): build multiplatform images on push to main or workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Proposal tests
 # run on all PRs
 on:
   pull_request:
+  workflow_dispatch:
   merge_group:
   push:
     branches: [main]
@@ -42,6 +43,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Docker multiplatform builds
+        run: |
+          DEFAULT_PLATFORM=linux/amd64
+          echo "DEFAULT_PLATFORM=$DEFAULT_PLATFORM" >> $GITHUB_ENV
+          if ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}; then
+            echo PLATFORMS=$DEFAULT_PLATFORM >> $GITHUB_ENV
+          else
+            echo PLATFORMS=linux/amd64,linux/arm64/v8 >> $GITHUB_ENV
+          fi
+
+      - name: Set up QEMU for cross-platform builds
+        uses: docker/setup-qemu-action@v3
+        if: ${{ env.PLATFORMS != env.DEFAULT_PLATFORM }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         # see https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
@@ -65,24 +80,18 @@ jobs:
           ./buildTestImages.ts
       - name: run test images
         run: ./runTestImages.ts
-
-      # XXX this should be instant because all the stages were already built in the steps above
-      # but it's re-building the last stage. This is deemed good enough for now.
-      # see https://github.com/moby/moby/issues/34715
-      - name: Build and push complete image
+      
+      # XXX this should be instant for the local platform because all the stages
+      # were already built in the steps above but it's re-building the last
+      # stage. This is deemed good enough for now.  see
+      # https://github.com/moby/moby/issues/34715
+      - name: Build and push images
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: ${{ env.PLATFORMS }}
           # push to registry on every repo push. A PR #2 will push with tag `pr-2` and `main` will have tag `main`.
           # See https://github.com/docker/metadata-action?tab=readme-ov-file#basic.
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: notify on failure
-        if: failure() && github.event_name != 'pull_request'
-        uses: ./.github/actions/notify-status
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          from: ${{ secrets.NOTIFY_EMAIL_FROM }}
-          to: ${{ secrets.NOTIFY_EMAIL_TO }}
-          password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Proposals run or planned for Mainnet (agoric-3)
 This repo serves several functions:
 
 - verify building an image with in which known proposals have executed
-- publishing an image with all passed proposals
+- publishing a multiplatform image with all passed proposals
 - verify that certain tests pass after each proposal
 
 # Design
@@ -82,9 +82,9 @@ To add a proposal, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 This repo publishes an image of the synthetic agoric-3 chain with all proposals that have "passed" (defined in this repo as having a proposal number).
 
-The CI builds on every push to the trunk branch, (`main`), or a PR branch. You can view all versions at https://github.com/agoric/agoric-3-proposals/pkgs/container/agoric-3-proposals/versions
+The CI builds multiplatform images on every push to the trunk branch, (`main`), and for speed, only default worker platform images for PR branches. You can view all versions at https://github.com/agoric/agoric-3-proposals/pkgs/container/agoric-3-proposals/versions
 
-The versions built from the main branch are at: `ghcr.io/agoric/agoric-3-proposals:main`. For each PR, they're at a URL like `ghcr.io/agoric/agoric-3-proposals:pr-11`.
+The multiplatform versions built from the main branch are at: `ghcr.io/agoric/agoric-3-proposals:main`. For each PR, default worker platform images are at a URL like `ghcr.io/agoric/agoric-3-proposals:pr-11`.
 
 If you RUN this image, you'll get a working chain running `agd` until you terminate,
 


### PR DESCRIPTION
Publish multiplatform images for main branch pushes.
