### PR TITLE
ci(docker): build each platform in a different worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
     strategy:
       matrix:
         platform: ${{ fromJSON(needs.platforms.outputs.platforms) }}
-    runs-on: ${{ contains(matrix.platform, '/arm') && 'macos-latest-xlarge' || 'ubuntu-latest' }}
+    # Run on our own self-hosted ARM64 machine if the platform is ARMish.
+    runs-on: ${{ contains(matrix.platform, '/arm') && fromJSON('["self-hosted","Linux","ARM64"]') || 'ubuntu-latest' }}
     steps:
       - name: free up disk space
+        if: ${{ !contains(matrix.platform, '/arm') }}
         run: |
           # Workaround to provide additional free space for testing.
           #   https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
@@ -70,7 +72,6 @@ jobs:
 
       - name: Set up QEMU for cross-platform builds
         uses: docker/setup-qemu-action@v3
-        if: ${{ matrix.platform != env.DEFAULT_PLATFORM }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,33 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  platforms:
+    runs-on: ubuntu-latest
+    outputs:
+      default: '${{ steps.platforms.outputs.default }}'
+      platforms: '${{ steps.platforms.outputs.platforms }}'
+    steps:
+      - name: Compute Docker platforms
+        id: platforms
+        run: |
+          DEFAULT_PLATFORM=linux/amd64
+          echo "default=$DEFAULT_PLATFORM" >> $GITHUB_OUTPUT
+          if ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}; then
+            platforms='["'"$DEFAULT_PLATFORM"'"]'
+          else
+            platforms='["linux/amd64","linux/arm64/v8"]'
+          fi
+          echo "platforms=$platforms" >> $GITHUB_OUTPUT
+    
   # see https://docs.docker.com/build/ci/github-actions/test-before-push/
   test-proposals:
-    strategy:
-      matrix:
-        platform: [linux/amd64]
-    runs-on: ubuntu-latest
+    needs: [platforms]
     # UNTIL https://github.com/Agoric/agoric-3-proposals/issues/2
     timeout-minutes: 120
+    strategy:
+      matrix:
+        platform: ${{ fromJSON(needs.platforms.outputs.platforms) }}
+    runs-on: ${{ contains(matrix.platform, '/arm') && 'macos-latest-xlarge' || 'ubuntu-latest' }}
     steps:
       - name: free up disk space
         run: |
@@ -39,11 +58,19 @@ jobs:
           echo "=== After cleanup:"
           df -h
 
+      - name: Set environment
+        run: |
+          echo "DEFAULT_PLATFORM=${{ needs.platforms.outputs.default }}" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU for cross-platform builds
+        uses: docker/setup-qemu-action@v3
+        if: ${{ matrix.platform != env.DEFAULT_PLATFORM }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -65,30 +92,88 @@ jobs:
       - run: corepack enable
       - run: yarn install
 
-      - name: build test images
+      - name: build test images ${{ matrix.platform }} == ${{ env.DEFAULT_PLATFORM }}
         run: |
           docker info
-          node_modules/.bin/synthetic-chain build
+          node_modules/.bin/synthetic-chain build ${{ matrix.platform == env.DEFAULT_PLATFORM && ' ' || '--dry' }}
       - name: run test images
+        if: ${{ matrix.platform == env.DEFAULT_PLATFORM }}
         run: node_modules/.bin/synthetic-chain test
 
-      # XXX this should be instant because all the stages were already built in the steps above
-      # but it's re-building the last stage. This is deemed good enough for now.
-      # see https://github.com/moby/moby/issues/34715
-      - name: Build and push complete image
+      - name: Compute tags
+        id: docker-tags
+        run: |
+          sep=
+          SUFFIXED=
+          uarch=$(echo "${{ matrix.platform }}" | tr / _)
+          for TAG in ${{ steps.meta.outputs.tags }}; do
+            SUFFIXED="$SUFFIXED$sep$TAG-$uarch"
+            if test -z "$sep"; then
+              sep=,
+              echo "tag=$TAG-$uarch" >> $GITHUB_OUTPUT
+            fi
+          done
+          echo "tags=$SUFFIXED" >> $GITHUB_OUTPUT
+      
+      # XXX this should be instant for the local platform because all the stages
+      # were already built in the steps above but it's re-building the last
+      # stage. This is deemed good enough for now.  see
+      # https://github.com/moby/moby/issues/34715
+      - name: Build and push images
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           # push to registry on every repo push. A PR #2 will push with tag `pr-2` and `main` will have tag `main`.
           # See https://github.com/docker/metadata-action?tab=readme-ov-file#basic.
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.docker-tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: notify on failure
-        if: failure() && github.event_name != 'pull_request'
-        uses: ./.github/actions/notify-status
+
+  # Publish the build's multiarch images to Docker Registry.
+  docker-publish-multiarch:
+    needs: [test-proposals, platforms]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          from: ${{ secrets.NOTIFY_EMAIL_FROM }}
-          to: ${{ secrets.NOTIFY_EMAIL_TO }}
-          password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
+          buildkitd-flags: --debug
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+      - name: Compute tags
+        id: docker-tags
+        run: |
+          echo "tags=${{ steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
+      
+      - name: Push multiarch image
+        run: |
+          set -ex
+          for TAG in ${{ steps.docker-tags.outputs.tags }}; do
+            sources=
+            for ARCH in ${{ join(fromJson(needs.platforms.outputs.platforms), ' ') }}; do
+              uarch=$(echo "$ARCH" | tr / _)
+              BUILD_TAG="$TAG-$uarch"
+              sources="$sources $BUILD_TAG"
+            done
+            docker buildx imagetools create --tag "$TAG"$sources
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Proposal tests
 # run on all PRs
 on:
   pull_request:
+  workflow_dispatch:
   merge_group:
   push:
     branches: [main]
@@ -28,6 +29,7 @@ jobs:
           DEFAULT_PLATFORM=linux/amd64
           echo "default=$DEFAULT_PLATFORM" >> $GITHUB_OUTPUT
           if ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}; then
+            # JSON-encoded list consisting only of the default platform.
             platforms='["'"$DEFAULT_PLATFORM"'"]'
           else
             platforms='["linux/amd64","linux/arm64/v8"]'
@@ -105,11 +107,14 @@ jobs:
         id: docker-tags
         run: |
           sep=
+          # A list of comma-separated tags to merge in the final image.
           SUFFIXED=
+          # Our platform, replacing slashes with underscores.
           uarch=$(echo "${{ matrix.platform }}" | tr / _)
           for TAG in ${{ steps.meta.outputs.tags }}; do
             SUFFIXED="$SUFFIXED$sep$TAG-$uarch"
             if test -z "$sep"; then
+              # The first tag (suffixed with our architecture) is the one we build.
               sep=,
               echo "tag=$TAG-$uarch" >> $GITHUB_OUTPUT
             fi
@@ -169,6 +174,7 @@ jobs:
       - name: Push multiarch image
         run: |
           set -ex
+          # Push all tags, comprised of all architectures, to the registry.
           for TAG in ${{ steps.docker-tags.outputs.tags }}; do
             sources=
             for ARCH in ${{ join(fromJson(needs.platforms.outputs.platforms), ' ') }}; do
@@ -178,3 +184,12 @@ jobs:
             done
             docker buildx imagetools create --tag "$TAG"$sources
           done
+
+      - name: notify on failure
+        if: failure() && github.event_name != 'pull_request'
+        uses: ./.github/actions/notify-status
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          from: ${{ secrets.NOTIFY_EMAIL_FROM }}
+          to: ${{ secrets.NOTIFY_EMAIL_TO }}
+          password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,21 +89,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # The .ts scripts depend upon this
-      - run: npm install --global tsx
-      # Enable corepack for packageManager config
-      - run: corepack enable
-      - run: yarn install
-
-      - name: build test images ${{ matrix.platform }} == ${{ env.DEFAULT_PLATFORM }}
-        run: |
-          docker info
-          node_modules/.bin/synthetic-chain build ${{ matrix.platform == env.DEFAULT_PLATFORM && ' ' || '--dry' }}
-      - name: run test images
-        if: ${{ matrix.platform == env.DEFAULT_PLATFORM }}
-        run: node_modules/.bin/synthetic-chain test
-
-      - name: Compute tags
+      - name: Compute Docker tags
         id: docker-tags
         run: |
           sep=
@@ -116,10 +102,24 @@ jobs:
             if test -z "$sep"; then
               # The first tag (suffixed with our architecture) is the one we build.
               sep=,
-              echo "tag=$TAG-$uarch" >> $GITHUB_OUTPUT
+              echo "tag=$TAG-$uarch" | tee -a $GITHUB_OUTPUT
             fi
           done
-          echo "tags=$SUFFIXED" >> $GITHUB_OUTPUT
+          echo "tags=$SUFFIXED" | tee -a $GITHUB_OUTPUT
+
+      # The .ts scripts depend upon this
+      - run: tsx --version || npm install --global tsx
+      # Enable corepack for packageManager config
+      - run: corepack enable || sudo corepack enable
+      - run: yarn install
+
+      - name: build test images ${{ matrix.platform }} == ${{ env.DEFAULT_PLATFORM }}
+        run: |
+          docker info
+          node_modules/.bin/synthetic-chain build ${{ matrix.platform == env.DEFAULT_PLATFORM && ' ' || '--dry' }}
+      - name: run test images
+        if: ${{ matrix.platform == env.DEFAULT_PLATFORM }}
+        run: node_modules/.bin/synthetic-chain test
       
       # XXX this should be instant for the local platform because all the stages
       # were already built in the steps above but it's re-building the last


### PR DESCRIPTION
This is an optimisation to reduce the amount of disk space and build time needed on each worker.  It currently uses a `self-hosted` runner for creating ARM images, falling back to standard `ubuntu-latest` GitHub runners.
