### PR TITLE
refactor: config proposal within package.json

### DIFF
--- a/common.ts
+++ b/common.ts
@@ -26,11 +26,12 @@ export type CoreEvalProposal = ProposalCommon & {
 export type ProposalInfo = SoftwareUpgradeProposal | CoreEvalProposal;
 
 function readInfo(proposalPath: string): ProposalInfo {
-  const configPath = path.join('proposals', proposalPath, 'config.json');
-  const config = fs.readFileSync(configPath, 'utf-8');
+  const packageJsonPath = path.join('proposals', proposalPath, 'package.json');
+  const packageJson = fs.readFileSync(packageJsonPath, 'utf-8');
+  const { agoricProposal } = JSON.parse(packageJson);
   const [proposalIdentifier, proposalName] = proposalPath.split(':');
   return {
-    ...JSON.parse(config),
+    ...agoricProposal,
     proposalIdentifier,
     proposalName,
   };

--- a/proposals/16:upgrade-8/config.json
+++ b/proposals/16:upgrade-8/config.json
@@ -1,5 +1,0 @@
-{
-    "sdkImageTag": "29",
-    "planName": "agoric-upgrade-8",
-    "type": "Software Upgrade Proposal"
-}

--- a/proposals/16:upgrade-8/package.json
+++ b/proposals/16:upgrade-8/package.json
@@ -1,0 +1,7 @@
+{
+    "agoricProposal": {
+        "sdkImageTag": "29",
+        "planName": "agoric-upgrade-8",
+        "type": "Software Upgrade Proposal"
+    }
+}

--- a/proposals/29:upgrade-9/config.json
+++ b/proposals/29:upgrade-9/config.json
@@ -1,6 +1,0 @@
-{
-    "releaseNotes": "https://github.com/Agoric/agoric-sdk/releases/tag/pismoC",
-    "sdkImageTag": "31",
-    "planName": "agoric-upgrade-9",
-    "type": "Software Upgrade Proposal"
-}

--- a/proposals/29:upgrade-9/package.json
+++ b/proposals/29:upgrade-9/package.json
@@ -1,0 +1,8 @@
+{
+    "agoricProposal": {
+        "releaseNotes": "https://github.com/Agoric/agoric-sdk/releases/tag/pismoC",
+        "sdkImageTag": "31",
+        "planName": "agoric-upgrade-9",
+        "type": "Software Upgrade Proposal"
+    }
+}

--- a/proposals/34:upgrade-10/config.json
+++ b/proposals/34:upgrade-10/config.json
@@ -1,6 +1,0 @@
-{
-  "releaseNotes": "https://github.com/Agoric/agoric-sdk/releases/tag/mainnet1B-rc3",
-  "sdkImageTag": "35",
-  "planName": "agoric-upgrade-10",
-  "type": "Software Upgrade Proposal"
-}

--- a/proposals/34:upgrade-10/package.json
+++ b/proposals/34:upgrade-10/package.json
@@ -1,4 +1,10 @@
 {
+    "agoricProposal": {
+        "releaseNotes": "https://github.com/Agoric/agoric-sdk/releases/tag/mainnet1B-rc3",
+        "sdkImageTag": "35",
+        "planName": "agoric-upgrade-10",
+        "type": "Software Upgrade Proposal"
+    },
     "type": "module",
     "license": "Apache-2.0",
     "dependencies": {

--- a/proposals/43:upgrade-11/config.json
+++ b/proposals/43:upgrade-11/config.json
@@ -1,6 +1,0 @@
-{
-  "releaseNotes": "https://github.com/Agoric/agoric-sdk/releases/tag/agoric-upgrade-11",
-  "sdkImageTag": "36",
-  "planName": "agoric-upgrade-11",
-  "type": "Software Upgrade Proposal"
-}

--- a/proposals/43:upgrade-11/package.json
+++ b/proposals/43:upgrade-11/package.json
@@ -1,4 +1,10 @@
 {
+    "agoricProposal": {
+        "releaseNotes": "https://github.com/Agoric/agoric-sdk/releases/tag/agoric-upgrade-11",
+        "sdkImageTag": "36",
+        "planName": "agoric-upgrade-11",
+        "type": "Software Upgrade Proposal"
+    },
     "type": "module",
     "license": "Apache-2.0",
     "dependencies": {

--- a/proposals/49:smart-wallet-nft/config.json
+++ b/proposals/49:smart-wallet-nft/config.json
@@ -1,3 +1,0 @@
-{
-    "type": "/agoric.swingset.CoreEvalProposal"
-}

--- a/proposals/49:smart-wallet-nft/package.json
+++ b/proposals/49:smart-wallet-nft/package.json
@@ -1,4 +1,7 @@
 {
+    "agoricProposal": {
+        "type": "/agoric.swingset.CoreEvalProposal"
+    },
     "type": "module",
     "license": "Apache-2.0",
     "dependencies": {

--- a/proposals/53:kread-start/config.json
+++ b/proposals/53:kread-start/config.json
@@ -1,3 +1,0 @@
-{
-    "type": "/agoric.swingset.CoreEvalProposal"
-}

--- a/proposals/53:kread-start/package.json
+++ b/proposals/53:kread-start/package.json
@@ -1,4 +1,7 @@
 {
+  "agoricProposal": {
+    "type": "/agoric.swingset.CoreEvalProposal"
+  },
   "type": "module",
   "license": "Apache-2.0",
   "dependencies": {

--- a/proposals/55:statom-vaults/config.json
+++ b/proposals/55:statom-vaults/config.json
@@ -1,3 +1,0 @@
-{
-    "type": "/agoric.swingset.CoreEvalProposal"
-}

--- a/proposals/55:statom-vaults/package.json
+++ b/proposals/55:statom-vaults/package.json
@@ -1,4 +1,7 @@
 {
+    "agoricProposal": {
+        "type": "/agoric.swingset.CoreEvalProposal"
+    },
     "type": "module",
     "license": "Apache-2.0",
     "dependencies": {

--- a/proposals/63:upgrade-12/config.json
+++ b/proposals/63:upgrade-12/config.json
@@ -1,6 +1,0 @@
-{
-    "releaseNotes": "https://github.com/Agoric/agoric-sdk/releases/tag/agoric-upgrade-12",
-    "sdkImageTag": "38",
-    "planName": "agoric-upgrade-12",
-    "type": "Software Upgrade Proposal"
-}

--- a/proposals/63:upgrade-12/package.json
+++ b/proposals/63:upgrade-12/package.json
@@ -1,4 +1,10 @@
 {
+    "agoricProposal": {
+        "releaseNotes": "https://github.com/Agoric/agoric-sdk/releases/tag/agoric-upgrade-12",
+        "sdkImageTag": "38",
+        "planName": "agoric-upgrade-12",
+        "type": "Software Upgrade Proposal"
+    },
     "type": "module",
     "license": "Apache-2.0",
     "dependencies": {

--- a/proposals/b:zoe1/config.json
+++ b/proposals/b:zoe1/config.json
@@ -1,3 +1,0 @@
-{
-    "type": "/agoric.swingset.CoreEvalProposal"
-}

--- a/proposals/b:zoe1/package.json
+++ b/proposals/b:zoe1/package.json
@@ -1,4 +1,7 @@
 {
+    "agoricProposal": {
+        "type": "/agoric.swingset.CoreEvalProposal"
+    },
     "type": "module",
     "license": "Apache-2.0",
     "dependencies": {


### PR DESCRIPTION
I had a thought that each proposal test is a package, so let's put the essential info in the package.json.

Taking this further, the `test.sh` and `eval.sh` could be package scripts.

This just moves the config for now.

Tested by rebuilding Dockerfile and seeing that it's exactly the same.