### PR TITLE
ci: add new `platform` matrix to be required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ env:
 jobs:
   # see https://docs.docker.com/build/ci/github-actions/test-before-push/
   test-proposals:
+    strategy:
+      matrix:
+        platform: [linux/amd64]
     runs-on: ubuntu-latest
     # UNTIL https://github.com/Agoric/agoric-3-proposals/issues/2
     timeout-minutes: 120


### PR DESCRIPTION
A simple change to prepare for multiplatform docker builds (#32).

The plan:
1. ensure that `test-proposals (linux/amd64)` passes for this PR
2. get an approving review
3. change branch protection requirements from `test-proposals` to `test-proposals (linux/amd64)` and rapidly thereafter:
4. merge this PR to main
