### PR TITLE
fix: miscellaneous cleanups

### DIFF
--- a/packages/synthetic-chain/src/lib/agd-lib.js
+++ b/packages/synthetic-chain/src/lib/agd-lib.js
@@ -79,8 +79,8 @@ export const makeAgd = ({ execFileSync }) => {
           ...keyringArgs,
           ...[`--from`, from],
           'tx',
-          ...txArgs,
           ...['--broadcast-mode', 'block'],
+          ...txArgs,
           ...yesArg,
           ...outJson,
         ];

--- a/packages/synthetic-chain/src/lib/cliHelper.js
+++ b/packages/synthetic-chain/src/lib/cliHelper.js
@@ -17,7 +17,7 @@ export const agd = {
     return JSON.parse(data);
   },
   tx: async (...params) => {
-    const newParams = ['tx', ...params, '-o json'];
+    const newParams = ['tx', '-bblock', ...params, '-o json'];
     const data = await executeCommand(BINARY, newParams, { shell: true });
     return JSON.parse(data);
   },

--- a/packages/synthetic-chain/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/env_setup.sh
@@ -80,10 +80,10 @@ provisionSmartWallet() {
   addr="$1"
   amount="$2"
   echo "funding $addr"
-  agd tx bank send "validator" "$addr" "$amount" -y --keyring-backend=test --chain-id="$CHAINID"
+  agd tx -bblock bank send "validator" "$addr" "$amount" -y --keyring-backend=test --chain-id="$CHAINID"
   waitForBlock
   echo "provisioning $addr"
-  agd tx swingset provision-one my-wallet "$addr" SMART_WALLET --keyring-backend=test --yes --chain-id="$CHAINID" --from="$addr"
+  agd tx -bblock swingset provision-one my-wallet "$addr" SMART_WALLET --keyring-backend=test --yes --chain-id="$CHAINID" --from="$addr"
   echo "Waiting for wallet $addr to reach vstorage"
   waitForBlock 5
   echo "Reading $addr from vstorage"
@@ -164,9 +164,9 @@ voteLatestProposalAndWait() {
   waitForBlock
   proposal=$($binary q gov proposals -o json | jq -r '.proposals[-1].proposal_id')
   waitForBlock
-  $binary tx gov deposit $proposal 50000000ubld --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
+  $binary tx -bblock gov deposit $proposal 50000000ubld --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
   waitForBlock
-  $binary tx gov vote $proposal yes --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
+  $binary tx -bblock gov vote $proposal yes --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
   waitForBlock
 
   while true; do

--- a/packages/synthetic-chain/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/env_setup.sh
@@ -170,13 +170,15 @@ voteLatestProposalAndWait() {
   waitForBlock
 
   while true; do
-    status=$($binary q gov proposal $proposal -ojson | jq -r .status)
+    json=$($binary q gov proposal $proposal -ojson)
+    status=$(echo "$json" | jq -r .status)
     case $status in
     PROPOSAL_STATUS_PASSED)
       break
       ;;
-    PROPOSAL_STATUS_REJECTED)
-      echo "Proposal rejected"
+    PROPOSAL_STATUS_REJECTED | PROPOSAL_STATUS_FAILED)
+      echo "Proposal did not pass (status=$status)"
+      echo "$json" | jq .
       exit 1
       ;;
     *)

--- a/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+# The name of the binary is an implementation detail.
+agd () {
+  ag0 ${1+"$@"}
+}
+
 export CHAINID=agoriclocal
-ag0 init localnet --chain-id "$CHAINID"
+agd init localnet --chain-id "$CHAINID"
 
 allaccounts=("gov1" "gov2" "gov3" "user1" "validator")
 for i in "${allaccounts[@]}"; do
-  ag0 keys add $i --keyring-backend=test 2>&1 | tee "$HOME/.agoric/$i.out"
+  agd keys add $i --keyring-backend=test 2>&1 | tee "$HOME/.agoric/$i.out"
   cat "$HOME/.agoric/$i.out" | tail -n1 | tee "$HOME/.agoric/$i.key"
 done
 
@@ -25,7 +30,7 @@ contents="$(jq ".app_state.gov.deposit_params.min_deposit[0].denom = \"ubld\"" "
 contents="$(jq ".app_state.staking.params.bond_denom = \"ubld\"" "$HOME/.agoric/config/genesis.json")" && echo -E "${contents}" >"$HOME/.agoric/config/genesis.json"
 contents="$(jq ".app_state.slashing.params.signed_blocks_window = \"20000\"" "$HOME/.agoric/config/genesis.json")" && echo -E "${contents}" >"$HOME/.agoric/config/genesis.json"
 contents=$(jq '. * { app_state: { gov: { voting_params: { voting_period: "10s" } } } }' "$HOME/.agoric/config/genesis.json") && echo -E "${contents}" >"$HOME/.agoric/config/genesis.json"
-export GENACCT=$(ag0 keys show validator -a --keyring-backend="test")
+export GENACCT=$(agd keys show validator -a --keyring-backend="test")
 echo "Genesis Account $GENACCT"
 
 denoms=(
@@ -47,12 +52,12 @@ for i in "${denoms[@]}"; do
   coins="${coins},${camount}${i}"
 done
 
-ag0 add-genesis-account "$GENACCT" "$coins"
+agd add-genesis-account "$GENACCT" "$coins"
 
-ag0 gentx validator 5000000000ubld --keyring-backend="test" --chain-id "$CHAINID"
-ag0 collect-gentxs
-ag0 start --log_level warn &
-ag0_PID=$!
+agd gentx validator 5000000000ubld --keyring-backend="test" --chain-id "$CHAINID"
+agd collect-gentxs
+agd start --log_level warn &
+agd_PID=$!
 wait_for_bootstrap
 waitForBlock 2
 
@@ -68,7 +73,7 @@ else
   echo "Upgrade info is not valid JSON: $info"
   exit $status
 fi
-ag0 tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
+agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
   --upgrade-height="$height" --upgrade-info="$info" \
   --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
   --from=validator --chain-id="$CHAINID" \
@@ -80,7 +85,7 @@ voteLatestProposalAndWait
 echo "Chain in to-be-upgraded state for $UPGRADE_TO"
 
 while true; do
-  latest_height=$(ag0 status | jq -r .SyncInfo.latest_block_height)
+  latest_height=$(agd status | jq -r .SyncInfo.latest_block_height)
   if [ "$latest_height" -ge "$height" ]; then
     echo "Upgrade height for $UPGRADE_TO reached. Killing agd"
     echo "(CONSENSUS FAILURE above for height $height is expected)"
@@ -91,5 +96,5 @@ while true; do
   fi
 done
 
-kill $ag0_PID
+kill $agd_PID
 echo "state directory $HOME/.agoric ready for upgrade to $UPGRADE_TO"

--- a/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
@@ -81,13 +81,13 @@ echo "Chain in to-be-upgraded state for $UPGRADE_TO"
 
 while true; do
   latest_height=$(ag0 status | jq -r .SyncInfo.latest_block_height)
-  if [ "$latest_height" != "$height" ]; then
-    echo "Waiting for upgrade height to be reached (need $height, have $latest_height)"
-    sleep 1
-  else
-    echo "Upgrade height for $UPGRADE_TO reached. Killing ag0"
+  if [ "$latest_height" -ge "$height" ]; then
+    echo "Upgrade height for $UPGRADE_TO reached. Killing agd"
     echo "(CONSENSUS FAILURE above for height $height is expected)"
     break
+  else
+    echo "Waiting for upgrade height for $UPGRADE_TO to be reached (need $height, have $latest_height)"
+    sleep 1
   fi
 done
 

--- a/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
@@ -72,7 +72,7 @@ else
   echo "Upgrade info is not valid JSON: $info"
   exit $status
 fi
-agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
+agd tx -bblock gov submit-proposal software-upgrade "$UPGRADE_TO" \
   --upgrade-height="$height" --upgrade-info="$info" \
   --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
   --from=validator --chain-id="$CHAINID" \

--- a/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
@@ -62,12 +62,11 @@ wait_for_bootstrap
 waitForBlock 2
 
 voting_period_s=10
-latest_height=$(ag0 status | jq -r .SyncInfo.latest_block_height)
-height=$(($latest_height + $voting_period_s + 10))
-
+latest_height=$(agd status | jq -r .SyncInfo.latest_block_height)
+height=$((latest_height + voting_period_s + 20))
 info=${UPGRADE_INFO-"{}"}
 if echo "$info" | jq .; then
-  :
+  echo "upgrade-info: $info"
 else
   status=$?
   echo "Upgrade info is not valid JSON: $info"
@@ -90,10 +89,9 @@ while true; do
     echo "Upgrade height for $UPGRADE_TO reached. Killing agd"
     echo "(CONSENSUS FAILURE above for height $height is expected)"
     break
-  else
-    echo "Waiting for upgrade height for $UPGRADE_TO to be reached (need $height, have $latest_height)"
-    sleep 1
   fi
+  echo "Waiting for upgrade height for $UPGRADE_TO to be reached (need $height, have $latest_height)"
+  sleep 1
 done
 
 kill $agd_PID

--- a/packages/synthetic-chain/upgrade-test-scripts/start_to_to.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_to_to.sh
@@ -25,7 +25,7 @@ else
   echo "Upgrade info is not valid JSON: $info"
   exit $status
 fi
-agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
+agd tx -bblock gov submit-proposal software-upgrade "$UPGRADE_TO" \
   --upgrade-height="$height" --upgrade-info="$info" \
   --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
   --from=validator --chain-id="$CHAINID" \

--- a/packages/synthetic-chain/upgrade-test-scripts/start_to_to.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_to_to.sh
@@ -16,7 +16,7 @@ fi
 
 voting_period_s=10
 latest_height=$(agd status | jq -r .SyncInfo.latest_block_height)
-height=$((latest_height + voting_period_s + 10))
+height=$((latest_height + voting_period_s + 20))
 info=${UPGRADE_INFO-"{}"}
 if echo "$info" | jq .; then
   echo "upgrade-info: $info"

--- a/packages/synthetic-chain/upgrade-test-scripts/start_to_to.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_to_to.sh
@@ -38,14 +38,13 @@ echo "Chain in to-be-upgraded state for $UPGRADE_TO"
 
 while true; do
   latest_height=$(agd status | jq -r .SyncInfo.latest_block_height)
-  if [ "$latest_height" != "$height" ]; then
-    echo "Waiting for upgrade height for $UPGRADE_TO to be reached (need $height, have $latest_height)"
-    sleep 1
-  else
+  if [ "$latest_height" -ge "$height" ]; then
     echo "Upgrade height for $UPGRADE_TO reached. Killing agd"
     echo "(CONSENSUS FAILURE above for height $height is expected)"
     break
   fi
+  echo "Waiting for upgrade height for $UPGRADE_TO to be reached (need $height, have $latest_height)"
+  sleep 1
 done
 
 sleep 2

--- a/proposals/16:upgrade-8/use.sh
+++ b/proposals/16:upgrade-8/use.sh
@@ -22,7 +22,7 @@ waitForBlock 2
 waitForBlock 3
 # fund provision pool
 stakeamount="20000000${USDC_DENOM}"
-agd tx bank send "validator" "agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346" "$stakeamount" -y --keyring-backend=test --chain-id="$CHAINID"
+agd tx bank send "validator" "agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346" "$stakeamount" -y --keyring-backend=test --chain-id="$CHAINID" -bblock
 waitForBlock 3
 
 govaccounts=("$GOV1ADDR" "$GOV2ADDR" "$GOV3ADDR")


### PR DESCRIPTION
While trying to build Docker images with QEMU, I fixed a few issues with sensitivity to races and timeouts.  Here they are:

- abort on `PROPOSAL_STATUS_FAILED`, which means the upgrade was scheduled to start before the voting period was over
- if upgrade height is passed, still treat it as needing to kill the chain
- increase `software-upgrade` height to mitigate the `PROPOSAL_STATUS_FAILED` problems
- wait for block inclusion when submitting transactions

Also for my sanity when working on the `start_*.sh` scripts:
- alias `agd` to `ag0` in `start_ag0.sh` to reduce noise when trying to compare or copy-and-paste code from `start_to_to.sh`.