### PR TITLE
stop minimum-gas warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If the proposal is _pending_ and does not yet have a number, use a letter. The p
 
 ### Files
 
-- `config.json` specifies what kind of proposal it is. If it's a "Software Upgrade Proposal" it also includes additional parameters.
+- `package.json` specifies what kind of proposal it is in a `agoricProposal` field. If it's a "Software Upgrade Proposal" it also includes additional parameters.
 - `use.sh` is the script that will be run in the USE stage of the build
 - `test.sh` is the script that will be _included_ in the TEST stage of the build, and run in CI
 

--- a/proposals/29:upgrade-9/test.sh
+++ b/proposals/29:upgrade-9/test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 source /usr/src/upgrade-test-scripts/env_setup.sh
 
+test_not_val "$(cat /root/.agoric/psm_metrics.json | wc -l)" "0" "psm metrics shouldnt be empty"
+test_not_val "$(cat /root/.agoric/psm_governance.json | wc -l)" "0" "psm gov params shouldnt be empty"
+
 # provision pool has right balance
 test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount') "19000000"
 

--- a/proposals/29:upgrade-9/use.sh
+++ b/proposals/29:upgrade-9/use.sh
@@ -15,6 +15,3 @@ sed --in-place=.bak s/'minimum-gas-prices = ""'/'minimum-gas-prices = "0ubld,0ui
 echo "Dumping PSM gov params..."
 timeout 3 agoric follow -l :published.psm.${PSM_PAIR}.metrics -o jsonlines | tee /root/.agoric/psm_metrics.json
 timeout 3 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | tee /root/.agoric/psm_governance.json
-
-test_not_val "$(cat /root/.agoric/psm_metrics.json | wc -l)" "0" "psm metrics shouldnt be empty"
-test_not_val "$(cat /root/.agoric/psm_governance.json | wc -l)" "0" "psm gov params shouldnt be empty"

--- a/proposals/29:upgrade-9/use.sh
+++ b/proposals/29:upgrade-9/use.sh
@@ -5,6 +5,9 @@ set -e
 
 source /usr/src/upgrade-test-scripts/env_setup.sh
 
+# Set to zero so tests don't have to pay gas (we're not testing that)
+sed --in-place=.bak s/'minimum-gas-prices = ""'/'minimum-gas-prices = "0ubld,0uist"'/ ~/.agoric/config/app.toml
+
 # NOTE: agoric follow doesn't have the `--first-value-only` parameter in this version
 # so we use a hack
 


### PR DESCRIPTION
Closes: #40 

Has a couple more cleanups too

- docs: proposal type is in package.json, not config.json (redundant with https://github.com/Agoric/agoric-3-proposals/pull/42/) 
- feat: set minimum-gas-prices explicitly to zero
- test: consolidate upgrade-9 tests
