### PR TITLE
Export state for genesis tinkering

### DIFF
--- a/makeDockerfile.ts
+++ b/makeDockerfile.ts
@@ -173,6 +173,7 @@ RUN mv /root/.agoric/data/priv_validator_state.json /root/.agoric/priv_validator
 RUN rm -rf /root/.agoric/data/*
 RUN mv /root/.agoric/priv_validator_state.json /root/.agoric/data/priv_validator_state.json
 RUN rm /root/.agoric/config/genesis.json
+RUN rm -rf /root/.agoric/config/swing-store
 RUN mv /root/.agoric/export/* /root/.agoric/config/
 
 WORKDIR /usr/src/upgrade-test-scripts

--- a/makeDockerfile.ts
+++ b/makeDockerfile.ts
@@ -167,6 +167,14 @@ FROM use-${lastProposal.proposalName}
 
 COPY --link --chmod=755 ./upgrade-test-scripts/start_agd.sh /usr/src/upgrade-test-scripts/
 
+RUN mkdir -p /root/.agoric/export
+RUN agd export --home /root/.agoric --export-dir /root/.agoric/export
+RUN mv /root/.agoric/data/priv_validator_state.json /root/.agoric/priv_validator_state.json
+RUN rm -rf /root/.agoric/data/*
+RUN mv /root/.agoric/priv_validator_state.json /root/.agoric/data/priv_validator_state.json
+RUN rm /root/.agoric/config/genesis.json
+RUN mv /root/.agoric/export/* /root/.agoric/config/
+
 WORKDIR /usr/src/upgrade-test-scripts
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT ./start_agd.sh


### PR DESCRIPTION
The current setup embeds the chain-id within the data folder. To operate the a3p container using an alternate chain-id, users must currently export the state manually and then re-import it after making necessary adjustments. This need arose for me when I attempted to run two separate a3p chains with distinct chain-ids on the same cluster for testing IBC relaying.

This proposed change involves exporting the state to the config folder and removing the data. The concept is that upon startup, the container will initially load the state from the exported genesis, allowing it to function as it previously did. Those who wish to use a different chain-id can simply modify the exported genesis before initiating the chain.