### PR TITLE
fix default entrypoint

### DIFF
--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -2,10 +2,11 @@
 // @ts-check
 
 import fs from 'node:fs';
-import type {
-  CoreEvalProposal,
-  ProposalInfo,
-  SoftwareUpgradeProposal,
+import {
+  lastPassedProposal,
+  type CoreEvalProposal,
+  type ProposalInfo,
+  type SoftwareUpgradeProposal,
 } from './proposals.js';
 
 /**
@@ -242,6 +243,12 @@ export function writeDockerfile(
     blocks.push(stage.TEST(proposal));
     previousProposal = proposal;
   }
+  // If one of the proposals is a passed proposal, make the latest one the default entrypoint
+  const lastPassed = lastPassedProposal(allProposals);
+  if (lastPassed) {
+    blocks.push(stage.DEFAULT(lastPassed));
+  }
+
   const contents = blocks.join('\n');
   fs.writeFileSync('Dockerfile', contents);
 }

--- a/packages/synthetic-chain/src/cli/proposals.ts
+++ b/packages/synthetic-chain/src/cli/proposals.ts
@@ -62,10 +62,10 @@ export const matchOneProposal = (
   return proposals[0];
 };
 
-export function lastPassedProposal(proposals: ProposalInfo[]): ProposalInfo {
-  const last = proposals.findLast(p => p.proposalIdentifier.match(/^\d/));
-  assert(last, 'no passed proposals');
-  return last;
+export function lastPassedProposal(
+  proposals: ProposalInfo[],
+): ProposalInfo | undefined {
+  return proposals.findLast(p => p.proposalIdentifier.match(/^\d/));
 }
 
 export function imageNameForProposal(


### PR DESCRIPTION
In the shuffle to Agoric-SDK and back, https://github.com/Agoric/agoric-3-proposals/pull/46 lost the `lastPassedProposal` functionality.

That made the `main` image include more pending proposals, which broke agoric-sdk integration builds. https://github.com/Agoric/agoric-sdk/pull/8731/commits/34fe9a4692ce687e70b294cfebfcf66f8630954f is a work-around that I'll revert after this image builds.

This fixed doesn't need a release because this new code won't execute outside this repo.