### PR TITLE
Read build info from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "dependencies": {
         "@agoric/synthetic-chain": "workspace:*"
     },
+    "agoricSyntheticChain": {
+        "fromTag": null
+    },
     "license": "Apache-2.0",
     "packageManager": "yarn@4.0.2"
 }

--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.0.2-0",
-  "stableVersion": "0.0.1",
+  "version": "0.0.2",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": "./cli.ts",
   "main": "index.js",

--- a/packages/synthetic-chain/src/cli/build.ts
+++ b/packages/synthetic-chain/src/cli/build.ts
@@ -3,6 +3,30 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { ProposalInfo, imageNameForProposal } from './proposals.js';
 
+export type AgoricSyntheticChainConfig = {
+  /**
+   * The agoric-3-proposals tag to build the agoric synthetic chain from.
+   * If `null`, the chain is built from an ag0 genesis.
+   * Defaults to `main`, which containing all passed proposals
+   */
+  fromTag: string | null;
+};
+
+const defaultConfig: AgoricSyntheticChainConfig = {
+  // Tag of the agoric-3 image containing all passed proposals
+  fromTag: 'main',
+};
+
+export function readBuildConfig(root: string): AgoricSyntheticChainConfig {
+  const packageJsonPath = path.join(root, 'package.json');
+  const packageJson = fs.readFileSync(packageJsonPath, 'utf-8');
+  const { agoricSyntheticChain } = JSON.parse(packageJson);
+
+  const config = { ...defaultConfig, ...agoricSyntheticChain };
+  // TODO mustMatch a shape
+  return config;
+}
+
 export const buildProposalSubmissions = (proposals: ProposalInfo[]) => {
   for (const proposal of proposals) {
     if (!('source' in proposal && proposal.source === 'build')) continue;

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -209,7 +209,7 @@ export function writeDockerfile(
     );
 
     if (proposal.type === '/agoric.swingset.CoreEvalProposal') {
-      blocks.push(stage.EVAL(proposal, previousProposal));
+      blocks.push(stage.EVAL(proposal, previousProposal!));
     } else if (proposal.type === 'Software Upgrade Proposal') {
       // handle the first proposal specially
       if (previousProposal) {

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -182,7 +182,7 @@ ENTRYPOINT ./start_agd.sh
 
 export function writeDockerfile(
   allProposals: ProposalInfo[],
-  fromTag?: string,
+  fromTag?: string | null,
 ) {
   // Each stage tests something about the left argument and prepare an upgrade to the right side (by passing the proposal and halting the chain.)
   // The upgrade doesn't happen until the next stage begins executing.

--- a/packages/synthetic-chain/tsconfig.json
+++ b/packages/synthetic-chain/tsconfig.json
@@ -3,6 +3,7 @@
         "allowImportingTsExtensions": true,
         "allowSyntheticDefaultImports": true,
         "checkJs": false, // opt in
+        "strict": true,
         "maxNodeModuleJsDepth": 2,
         "module": "NodeNext",
         "moduleResolution": "nodenext",

--- a/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_ag0.sh
@@ -17,6 +17,7 @@ sed -i.bak "s/^enable-unsafe-cors =.*/enable-unsafe-cors = true/" "$HOME/.agoric
 sed -i.bak "s/127.0.0.1:26657/0.0.0.0:26657/" "$HOME/.agoric/config/config.toml"
 sed -i.bak "s/cors_allowed_origins = \[\]/cors_allowed_origins = \[\"*\"\]/" "$HOME/.agoric/config/config.toml"
 sed -i.bak '/^\[api]/,/^\[/{s/^enable[[:space:]]*=.*/enable = true/}' "$HOME/.agoric/config/app.toml"
+sed -i.bak "s/^pruning =.*/pruning = \"nothing\"/" "$HOME/.agoric/config/app.toml"
 
 contents="$(jq ".app_state.crisis.constant_fee.denom = \"ubld\"" "$HOME/.agoric/config/genesis.json")" && echo -E "${contents}" >"$HOME/.agoric/config/genesis.json"
 contents="$(jq ".app_state.mint.params.mint_denom = \"ubld\"" "$HOME/.agoric/config/genesis.json")" && echo -E "${contents}" >"$HOME/.agoric/config/genesis.json"


### PR DESCRIPTION
Follow-up to #52, but instead of relying on new commands and positional parameters, the base build info is read from the `package.json` enclosing the `proposals`. This allows using a single and simple `synthetic-chain build` command, whether in a3p itself or in other repos integrations. It also provides a place in the future to configure the build of other a3p like images.

I have manually locally tested this change with https://github.com/Agoric/agoric-sdk/pull/8743.

A new version of the `synthetic-chain` package still needs to be published if approved.