### PR TITLE
feat(synthetic-chain): add proposal upgradeInfo support

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": "./cli.ts",
   "main": "index.js",

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -7,6 +7,7 @@ import {
   type CoreEvalProposal,
   type ProposalInfo,
   type SoftwareUpgradeProposal,
+  encodeUpgradeInfo,
 } from './proposals.js';
 
 /**
@@ -50,7 +51,7 @@ FROM ghcr.io/agoric/agoric-3-proposals:${fromTag} as use-${fromTag}
    * - Submit the software-upgrade proposal for planName and run until upgradeHeight, leaving the state-dir ready for next agd.
    */
   PREPARE(
-    { planName, proposalName }: SoftwareUpgradeProposal,
+    { planName, proposalName, upgradeInfo }: SoftwareUpgradeProposal,
     lastProposal: ProposalInfo,
   ) {
     return `
@@ -58,7 +59,9 @@ FROM ghcr.io/agoric/agoric-3-proposals:${fromTag} as use-${fromTag}
 
 # upgrading to ${planName}
 FROM use-${lastProposal.proposalName} as prepare-${proposalName}
-ENV UPGRADE_TO=${planName}
+ENV UPGRADE_TO=${planName} UPGRADE_INFO=${JSON.stringify(
+      encodeUpgradeInfo(upgradeInfo),
+    )}
 # base is a fresh sdk image so copy these supports
 COPY --link --chmod=755 ./upgrade-test-scripts/env_setup.sh ./upgrade-test-scripts/start_to_to.sh /usr/src/upgrade-test-scripts/
 

--- a/packages/synthetic-chain/src/cli/proposals.ts
+++ b/packages/synthetic-chain/src/cli/proposals.ts
@@ -12,6 +12,7 @@ type ProposalCommon = {
 export type SoftwareUpgradeProposal = ProposalCommon & {
   sdkImageTag: string;
   planName: string;
+  upgradeInfo?: unknown;
   releaseNodes: string;
   type: 'Software Upgrade Proposal';
 };
@@ -40,6 +41,10 @@ function readInfo(proposalPath: string): ProposalInfo {
     proposalIdentifier,
     proposalName,
   };
+}
+
+export function encodeUpgradeInfo(upgradeInfo: unknown): string {
+  return upgradeInfo != null ? JSON.stringify(upgradeInfo) : '';
 }
 
 export function readProposals(proposalsParent: string): ProposalInfo[] {


### PR DESCRIPTION
Plumbing of `UPGRADE_INFO` seem to have disappeared with `synthetic-chain`. This adds the capability back.

Manually tested in `agoric-sdk` with a core proposal installing the network vat on top of https://github.com/Agoric/agoric-sdk/pull/8747

Released as 0.0.3