### PR TITLE
fix: start_to_to.sh for backwards compat

### DIFF
--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -65,7 +65,7 @@ ENV UPGRADE_TO=${planName} UPGRADE_INFO=${JSON.stringify(
       encodeUpgradeInfo(upgradeInfo),
     )}
 
-COPY --link --chmod=755 ./upgrade-test-scripts/env_setup.sh ./upgrade-test-scripts/run_prepare.sh /usr/src/upgrade-test-scripts/
+COPY --link --chmod=755 ./upgrade-test-scripts/env_setup.sh ./upgrade-test-scripts/run_prepare.sh ./upgrade-test-scripts/start_to_to.sh /usr/src/upgrade-test-scripts/
 WORKDIR /usr/src/upgrade-test-scripts
 SHELL ["/bin/bash", "-c"]
 RUN ./run_prepare.sh
@@ -89,7 +89,7 @@ WORKDIR /usr/src/upgrade-test-scripts
 
 # base is a fresh sdk image so set up the proposal and its dependencies
 COPY --link --chmod=755 ./proposals/${proposalIdentifier}:${proposalName} /usr/src/proposals/${proposalIdentifier}:${proposalName}
-COPY --link --chmod=755 ./upgrade-test-scripts/env_setup.sh ./upgrade-test-scripts/run_execute.sh ./upgrade-test-scripts/install_deps.sh /usr/src/upgrade-test-scripts/
+COPY --link --chmod=755 ./upgrade-test-scripts/env_setup.sh ./upgrade-test-scripts/run_execute.sh  ./upgrade-test-scripts/start_to_to.sh ./upgrade-test-scripts/install_deps.sh /usr/src/upgrade-test-scripts/
 RUN --mount=type=cache,target=/root/.yarn ./install_deps.sh ${proposalIdentifier}:${proposalName}
 
 COPY --link --from=prepare-${proposalName} /root/.agoric /root/.agoric

--- a/packages/synthetic-chain/upgrade-test-scripts/start_to_to.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/start_to_to.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Prepare or execute an upgrade
+# XXX retained for backwards compatibility
+
+echo "DEPRECATED start_to_to; migrate start to @agoric/synthetic-chain 0.0.5 or later"
+
+grep -qF 'env_setup.sh' /root/.bashrc || echo "source /usr/src/upgrade-test-scripts/env_setup.sh" >>/root/.bashrc
+grep -qF 'printKeys' /root/.bashrc || echo "printKeys" >>/root/.bashrc
+
+source ./env_setup.sh
+
+startAgd
+
+if [[ -z "${UPGRADE_TO}" ]]; then
+  echo "no upgrade set.  running for a few blocks and exiting"
+  waitForBlock 5
+  exit 0
+fi
+
+voting_period_s=10
+latest_height=$(agd status | jq -r .SyncInfo.latest_block_height)
+height=$((latest_height + voting_period_s + 10))
+info=${UPGRADE_INFO-"{}"}
+if echo "$info" | jq .; then
+  echo "upgrade-info: $info"
+else
+  status=$?
+  echo "Upgrade info is not valid JSON: $info"
+  exit $status
+fi
+agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
+  --upgrade-height="$height" --upgrade-info="$info" \
+  --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
+  --from=validator --chain-id="$CHAINID" \
+  --yes --keyring-backend=test
+waitForBlock
+
+voteLatestProposalAndWait
+
+echo "Chain in to-be-upgraded state for $UPGRADE_TO"
+
+while true; do
+  latest_height=$(agd status | jq -r .SyncInfo.latest_block_height)
+  if [ "$latest_height" != "$height" ]; then
+    echo "Waiting for upgrade height for $UPGRADE_TO to be reached (need $height, have $latest_height)"
+    sleep 1
+  else
+    echo "Upgrade height for $UPGRADE_TO reached. Killing agd"
+    echo "(CONSENSUS FAILURE above for height $height is expected)"
+    break
+  fi
+done
+
+sleep 2
+killAgd
+echo "state directory $HOME/.agoric ready for upgrade to $UPGRADE_TO"


### PR DESCRIPTION
https://github.com/Agoric/agoric-3-proposals/pull/88 broke the tacit API of what files are in the Docker images available to downstream builds.

The downstream should be copying its own dependencies into the filesystem so that they aren't coupled to the @agoric/synthetic-chain used to produce the upstream images.

That's apparently not the case for [some branch in agoric-sdk](https://github.com/Agoric/agoric-3-proposals/pull/88#discussion_r1480765464) so this is a stop-gap until further investigation.