### PR TITLE
fix: handle new gov proposal query shape

### DIFF
--- a/packages/synthetic-chain/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/upgrade-test-scripts/env_setup.sh
@@ -172,7 +172,7 @@ test_not_val() {
 
 voteLatestProposalAndWait() {
   waitForBlock
-  proposal=$($binary q gov proposals -o json | jq -r '.proposals[-1].proposal_id')
+  proposal=$($binary q gov proposals -o json | jq -r '.proposals | last | if .proposal_id == null then .id else .proposal_id end')
   waitForBlock
   $binary tx -bblock gov deposit $proposal 50000000ubld --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
   waitForBlock


### PR DESCRIPTION
Partially handle the new response shape for gov proposal queries.

With cosmos 0.46, the proposal has an `id` field instead of `proposal_id` (it also has `messages` instead of `content`, but it looks like nothing is making use of that field as of now).

This also checks the proposal status before making the deposit or voting on it, and handles failed proposals in more places.