### PR TITLE
allow CoreEval with same bundles

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.0.7-2",
+  "version": "0.0.7-3",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": "dist/cli/cli.js",
   "main": "./dist/lib/index.js",

--- a/packages/synthetic-chain/src/lib/core-eval.ts
+++ b/packages/synthetic-chain/src/lib/core-eval.ts
@@ -63,23 +63,17 @@ export const passCoreEvalProposal = async (bundleInfos: BundleInfo[]) => {
   };
   const context = await makeTestContext(config);
 
-  await step('bundles not yet installed', async () => {
-    const loaded = loadedBundleIds(context.swingstore);
-    for (const { name, bundles, evals } of bundleInfos) {
-      console.log(
-        name,
-        evals[0].script,
-        evals.length,
-        'eval',
-        bundles.length,
-        'bundles',
-      );
-      for (const bundle of bundles) {
-        const { id } = bundleDetail(bundle);
-        assert(!loaded.includes(id));
-      }
-    }
-  });
+  console.log('Passing core evals...');
+  for (const { name, bundles, evals } of bundleInfos) {
+    console.log(
+      name,
+      evals[0].script,
+      evals.length,
+      'eval',
+      bundles.length,
+      'bundles',
+    );
+  }
 
   const bundleEntry = async (bundle: { endoZipBase64: string }) => {
     const getZipReader = async () => {


### PR DESCRIPTION
This removes the assertion that none of the bundles were previously installed.
Any already installed bundle will be skipped at the actual installation step.
