### PR TITLE
fix: vote on proposal by title

### DIFF
--- a/proposals/49:smart-wallet-nft/upgrade-wf.test.js
+++ b/proposals/49:smart-wallet-nft/upgrade-wf.test.js
@@ -300,7 +300,7 @@ test.serial('core eval proposal passes', async t => {
   t.log(txAbbr(result));
   t.is(result.code, 0);
 
-  const detail = await voteLatestProposalAndWait();
+  const detail = await voteLatestProposalAndWait(info.title);
   t.log(detail.proposal_id, detail.voting_end_time, detail.status);
   t.is(detail.status, 'PROPOSAL_STATUS_PASSED');
 });


### PR DESCRIPTION
If multiple tests attempt to pass a core eval (or really any proposal) concurrently, `voteLatestProposalAndWait` would only find the latest proposal. This PR plumbs a config with the `title` and `description` of the core eval proposal, and uses the title to find the corresponding pending proposal (there is no way to look up a proposal by original tx submission). `evalBundles` is modified to generate a title based on the submission dir name.