### PR TITLE
fix submit-proposal gas

### DIFF
--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -178,16 +178,19 @@ export SUBMIT_PROPOSAL_OPTS="--keyring-backend=test --chain-id=$CHAINID \
 		--yes --broadcast-mode block --from validator"
 
 voteLatestProposalAndWait() {
+  echo "start voteLatestProposalAndWait()"
   waitForBlock
   proposal=$($binary q gov proposals -o json | jq -r '.proposals | last | if .proposal_id == null then .id else .proposal_id end')
+  echo "Latest proposal: $proposal"
   waitForBlock
-  $binary tx -bblock gov deposit $proposal 50000000ubld --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
+  $binary tx -bblock gov deposit "$proposal" 50000000ubld --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
   waitForBlock
-  $binary tx -bblock gov vote $proposal yes --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
+  $binary tx -bblock gov vote "$proposal" yes --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
   waitForBlock
 
+  echo "Voted in proposal $proposal"
   while true; do
-    json=$($binary q gov proposal $proposal -ojson)
+    json=$($binary q gov proposal "$proposal" -ojson)
     status=$(echo "$json" | jq -r .status)
     case $status in
     PROPOSAL_STATUS_PASSED)

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -170,6 +170,13 @@ test_not_val() {
   fi
 }
 
+# gas=200000 is the default but gas used may be higher or lower. Setting it
+# to "auto" makes the proposal executions less brittle.
+GAS_ADJUSTMENT=1.2
+export SUBMIT_PROPOSAL_OPTS="--keyring-backend=test --chain-id=$CHAINID \
+		--gas=auto --gas-adjustment=$GAS_ADJUSTMENT \
+		--yes --broadcast-mode block --from validator"
+
 voteLatestProposalAndWait() {
   waitForBlock
   proposal=$($binary q gov proposals -o json | jq -r '.proposals | last | if .proposal_id == null then .id else .proposal_id end')

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -88,10 +88,12 @@ provisionSmartWallet() {
   addr="$1"
   amount="$2"
   echo "funding $addr"
-  agd tx -bblock bank send "validator" "$addr" "$amount" -y --keyring-backend=test --chain-id="$CHAINID"
+  # shellcheck disable=SC2086
+  agd tx bank send "validator" "$addr" "$amount" $SIGN_BROADCAST_OPTS
   waitForBlock
   echo "provisioning $addr"
-  agd tx -bblock swingset provision-one my-wallet "$addr" SMART_WALLET --keyring-backend=test --yes --chain-id="$CHAINID" --from="$addr"
+  # shellcheck disable=SC2086
+  agd tx swingset provision-one my-wallet "$addr" SMART_WALLET --from="$addr" $SIGN_BROADCAST_OPTS
   echo "Waiting for wallet $addr to reach vstorage"
   waitForBlock 5
   echo "Reading $addr from vstorage"
@@ -173,7 +175,7 @@ test_not_val() {
 # gas=200000 is the default but gas used may be higher or lower. Setting it
 # to "auto" makes the proposal executions less brittle.
 GAS_ADJUSTMENT=1.2
-export SUBMIT_PROPOSAL_OPTS="--keyring-backend=test --chain-id=$CHAINID \
+export SIGN_BROADCAST_OPTS="--keyring-backend=test --chain-id=$CHAINID \
 		--gas=auto --gas-adjustment=$GAS_ADJUSTMENT \
 		--yes --broadcast-mode block --from validator"
 
@@ -183,9 +185,11 @@ voteLatestProposalAndWait() {
   proposal=$($binary q gov proposals -o json | jq -r '.proposals | last | if .proposal_id == null then .id else .proposal_id end')
   echo "Latest proposal: $proposal"
   waitForBlock
-  $binary tx -bblock gov deposit "$proposal" 50000000ubld --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
+  # shellcheck disable=SC2086
+  $binary tx gov deposit "$proposal" 50000000ubld $SIGN_BROADCAST_OPTS
   waitForBlock
-  $binary tx -bblock gov vote "$proposal" yes --from=validator --chain-id="$CHAINID" --yes --keyring-backend test
+  # shellcheck disable=SC2086
+  $binary tx gov vote "$proposal" yes $SIGN_BROADCAST_OPTS
   waitForBlock
 
   echo "Voted in proposal $proposal"

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare.sh
@@ -54,11 +54,11 @@ else
   echo "Upgrade info is not valid JSON: $info"
   exit $status
 fi
-agd tx -bblock gov submit-proposal software-upgrade "$UPGRADE_TO" \
+# shellcheck disable=SC2086
+agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
   --upgrade-height="$height" --upgrade-info="$info" \
   --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
-  --from=validator --chain-id="$CHAINID" \
-  --yes --keyring-backend=test
+  ${SUBMIT_PROPOSAL_OPTS="--missing-env-setup"}
 waitForBlock
 
 voteLatestProposalAndWait

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare.sh
@@ -58,7 +58,7 @@ fi
 agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
   --upgrade-height="$height" --upgrade-info="$info" \
   --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
-  ${SUBMIT_PROPOSAL_OPTS="--missing-env-setup"}
+  ${SIGN_BROADCAST_OPTS="--missing-env-setup"}
 waitForBlock
 
 voteLatestProposalAndWait

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare_zero.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare_zero.sh
@@ -8,8 +8,7 @@ agd() {
   ag0 ${1+"$@"}
 }
 
-export CHAINID=agoriclocal
-agd init localnet --chain-id "$CHAINID"
+agd init localnet --chain-id agoriclocal
 
 allaccounts=("gov1" "gov2" "gov3" "user1" "validator")
 # WARNING: these mnemonics are purely for testing purposes, do not implement
@@ -81,11 +80,11 @@ else
   echo "Upgrade info is not valid JSON: $info"
   exit $status
 fi
-agd tx -bblock gov submit-proposal software-upgrade "$UPGRADE_TO" \
+# shellcheck disable=SC2086
+agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
   --upgrade-height="$height" --upgrade-info="$info" \
   --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
-  --from=validator --chain-id="$CHAINID" \
-  --yes --keyring-backend=test
+  ${SIGN_BROADCAST_OPTS="--missing-env-setup"}
 waitForBlock
 
 voteLatestProposalAndWait

--- a/packages/synthetic-chain/public/upgrade-test-scripts/start_to_to.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/start_to_to.sh
@@ -28,11 +28,11 @@ else
   echo "Upgrade info is not valid JSON: $info"
   exit $status
 fi
+# shellcheck disable=SC2086
 agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
   --upgrade-height="$height" --upgrade-info="$info" \
   --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
-  --from=validator --chain-id="$CHAINID" \
-  --yes --keyring-backend=test
+  ${SUBMIT_PROPOSAL_OPTS="--missing-env-setup"}
 waitForBlock
 
 voteLatestProposalAndWait

--- a/packages/synthetic-chain/public/upgrade-test-scripts/start_to_to.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/start_to_to.sh
@@ -32,7 +32,7 @@ fi
 agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
   --upgrade-height="$height" --upgrade-info="$info" \
   --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
-  ${SUBMIT_PROPOSAL_OPTS="--missing-env-setup"}
+  ${SIGN_BROADCAST_OPTS="--missing-env-setup"}
 waitForBlock
 
 voteLatestProposalAndWait

--- a/proposals/16:upgrade-8/use.sh
+++ b/proposals/16:upgrade-8/use.sh
@@ -24,7 +24,8 @@ waitForBlock 2
 waitForBlock 3
 # fund provision pool
 stakeamount="20000000${USDC_DENOM}"
-agd tx bank send "validator" "agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346" "$stakeamount" -y --keyring-backend=test --chain-id="$CHAINID" -bblock
+# shellcheck disable=SC2086
+agd tx bank send "validator" "agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346" "$stakeamount" ${SIGN_BROADCAST_OPTS="--missing-env-setup"}
 waitForBlock 3
 
 govaccounts=("$GOV1ADDR" "$GOV2ADDR" "$GOV3ADDR")

--- a/proposals/16:upgrade-8/use.sh
+++ b/proposals/16:upgrade-8/use.sh
@@ -109,8 +109,8 @@ agd query vstorage data published.psm.${PSM_PAIR}.governance
 # but it parses the vstorage in mainnet v11, not v8 ugh
 # test_val "$(agd query vstorage data published.psm.${PSM_PAIR}.governance | jq -r ".value|fromjson.values[0]|fromjson.body" | tr "#" " " | jq -r .current.MintLimit.value.value)" "+133337000000" "PSM MintLimit set correctly"
 
+BLD_PRE=$(agd q bank balances "$GOV1ADDR" --output=json --denom ubld | jq -r .amount)
 test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom uist | jq -r .amount)" "250000" "pre-swap: validate IST"
-test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom ubld | jq -r .amount)" "190000000" "pre-swap: validate BLD balance"
 test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom ${USDC_DENOM} | jq -r .amount)" "100000000" "pre-swap: validate USDC balance"
 
 echo DEBUG execute PSM swap
@@ -119,8 +119,8 @@ agops psm swap --pair ${PSM_PAIR} --wantMinted 10.00 --feePct 0.10 >|"$SWAP_OFFE
 agops perf satisfaction --from $GOV1ADDR --executeOffer "$SWAP_OFFER" --keyring-backend=test
 
 test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom uist | jq -r .amount)" "10260011" "post-swap: validate IST"
-test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom ubld | jq -r .amount)" "190000000" "post-swap: validate BLD balance"
 test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom ${USDC_DENOM} | jq -r .amount)" "89989989" "post-swap: validate USDC balance"
+test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom ubld | jq -r .amount)" "$BLD_PRE" "post-swap: validate BLD balance"
 
 waitForBlock 3
 

--- a/proposals/61:lo-bundle-cost/eval.sh
+++ b/proposals/61:lo-bundle-cost/eval.sh
@@ -5,13 +5,8 @@ set -e
 
 source /usr/src/upgrade-test-scripts/env_setup.sh
 
-GAS_ADJUSTMENT=1.2
-SIGN_BROADCAST_OPTS="--keyring-backend=test --chain-id=$CHAINID \
-		--gas=auto --gas-adjustment=$GAS_ADJUSTMENT \
-		--yes -b block"
-
+# shellcheck disable=SC2086
 agd tx gov submit-proposal param-change lower-bundle-cost.json \
-    $SIGN_BROADCAST_OPTS --from validator
+	${SUBMIT_PROPOSAL_OPTS="--missing-env-setup"}
 
 voteLatestProposalAndWait
-

--- a/proposals/61:lo-bundle-cost/eval.sh
+++ b/proposals/61:lo-bundle-cost/eval.sh
@@ -7,6 +7,6 @@ source /usr/src/upgrade-test-scripts/env_setup.sh
 
 # shellcheck disable=SC2086
 agd tx gov submit-proposal param-change lower-bundle-cost.json \
-	${SUBMIT_PROPOSAL_OPTS="--missing-env-setup"}
+	${SIGN_BROADCAST_OPTS="--missing-env-setup"}
 
 voteLatestProposalAndWait


### PR DESCRIPTION
https://github.com/Agoric/agoric-3-proposals/pull/120 was failing due to insufficient gas. E.g. the [build for prepare-upgrade-14-rc1](https://depot.dev/orgs/gtcxrhgg4x/projects/bqgtmlhmh8/builds/l84q1nzvwj/logs/sha256:8feb171d3f7f35d5ad55bd881d1ae42973dbdb2261a23d0d86e78256c71d2920) had:
```
raw_log: 'out of gas in location: WritePerByte; gasWanted: 200000, gasUsed: 206121:
  out of gas'
```

It has a fix but this pulls it out since that PR shouldn't merge to main.

This also includes the removal of the pending Zoe proposal because it's tested now in agoric-sdk and https://github.com/Agoric/agoric-3-proposals/pull/113, which will soon be merged.