### PR TITLE
chore: remove netstat debugging

### DIFF
--- a/.github/actions/notify-status/action.yml
+++ b/.github/actions/notify-status/action.yml
@@ -43,7 +43,7 @@ runs:
         from: ${{ inputs.from }}
     - name: Send GitHub trigger payload
       id: slack
-      uses: slackapi/slack-github-action@v1.24.0
+      uses: slackapi/slack-github-action@v1
       with:
         payload: |
           {


### PR DESCRIPTION
refs: #93 

We haven't seen that flake since the hypothesized fix https://github.com/Agoric/agoric-3-proposals/issues/93#issuecomment-1930672860

The debugging output of `netstat` causes the logs to grow too large for Github's UI to search them. So let's not wait any longer to remove the output.

I don't think this will really solve #93 so this doesn't close it