### PR TITLE
fix stale "latest" image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,17 +142,33 @@ jobs:
 
       # Push the images if the tests pass and this is not a PR
       - name: Push proposal "use" images
-        uses: depot/bake-action@v1
         # If we pushed from PRs, each one would overwrite main's (e.g. use-upgrade-8)
         # To push PR "use" images we'll need to qualify the tag (e.g. use-upgrade-8-pr-2).
         if: ${{ github.event_name != 'pull_request' }}
+        uses: depot/bake-action@v1
         with:
           files: |
             ./docker-bake.json
             ./docker-bake.hcl
             ${{ steps.meta.outputs.bake-file }}
-          # Include "latest" which is latest "use" image
-          targets: use, latest
+          targets: use
+          push: true
+
+      # Just like the "use" image above but has to begin after that ends
+      # because the "build" here is merely to retag the latest "use" image.
+      # We could do this with imagetools but this lets use keep the tagging logic
+      # in Bake instead of mixed into CI. This step should do hardly any building
+      # because its FROM image was just built above.
+      - name: Push "latest" image
+        # Same reason as for "use" images
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: depot/bake-action@v1
+        with:
+          files: |
+            ./docker-bake.json
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: latest
           push: true
 
       - name: notify on failure

--- a/README.md
+++ b/README.md
@@ -130,12 +130,14 @@ This repo publishes an image of the synthetic agoric-3 chain with all proposals 
 
 The CI builds on every push to the trunk branch, (`main`), or a PR branch. You can view all versions at https://github.com/agoric/agoric-3-proposals/pkgs/container/agoric-3-proposals/versions
 
-The versions built from the main branch are at: `ghcr.io/agoric/agoric-3-proposals:main`. For each PR, they're at a URL like `ghcr.io/agoric/agoric-3-proposals:pr-11`.
+PR builds don't push images.
+
+The trunk build pushes "use" images for each proposal and a "latest" which points to the highest passed proposal: `ghcr.io/agoric/agoric-3-proposals:latest`.
 
 If you RUN this image, you'll get a working chain running `agd` until you terminate,
 
 ```sh
-docker run ghcr.io/agoric/agoric-3-proposals:main
+docker run ghcr.io/agoric/agoric-3-proposals:latest
 ```
 
 Or locally,

--- a/proposals/61:lo-bundle-cost/test.sh
+++ b/proposals/61:lo-bundle-cost/test.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
-expected=20000000
+expected=20
 
 params="$(agd query swingset params -o json)"
-cost="$(echo $params | jq -r ".beans_per_unit | .[] | select(.key == \"storageByte\") | .beans" )"
+ucost="$(echo $params | jq -r ".beans_per_unit | .[] | select(.key == \"storageByte\") | .beans")"
+cost=$((ucost / 1000000))
 
 # fail if cost is not expected
 if [ "$cost" != "$expected" ]; then
@@ -13,4 +14,3 @@ if [ "$cost" != "$expected" ]; then
 else
     echo "Cost is $cost"
 fi
-


### PR DESCRIPTION
closes: #121 

# Test plan

Pushing the "latest" image shouldn't build anything. Confirmed by manually triggering the workflow to get the steps that are skipped in normal PRs. https://github.com/Agoric/agoric-3-proposals/actions/runs/8250580844/job/22565552157
```
Push "latest" image                10s
```