### PR TITLE
feat: move mnemonics out of disk

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": "dist/cli/cli.js",
   "main": "./dist/lib/index.js",

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -201,10 +201,12 @@ voteLatestProposalAndWait() {
 
 printKeys() {
   echo "========== GOVERNANCE KEYS =========="
-  for i in /usr/src/upgrade-test-scripts/keys_for_test_only/*.key; do
-    name=$(basename $i .key)
-    echo "$name:"$'\t'$(agd keys add $name --dry-run --recover --keyring-backend=test --output=json <$i | jq -r .address) || true
-    echo $'\t'$(cat $i)
+  allaccounts=("gov1" "gov2" "gov3" "user1" "user2" "validator")
+  for i in "${allaccounts[@]}"; do
+    echo "---------- $i -----------"
+    agd keys show --address --keyring-backend=test $i
+    agd keys export --unsafe --unarmored-hex --keyring-backend=test $i
+    echo "---------- $i -----------"
   done
   echo "========== GOVERNANCE KEYS =========="
 }

--- a/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/README.md
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/README.md
@@ -1,9 +1,0 @@
-# Keys for testing only
-
-These keys were made separately from the build to store in SCM. That way they are consistent for all testing.
-
-Previously we made them fresh with each build of the first stage, to ensure that application code would never be hard-coded to depend on certain keys.
-
-The downside was that tests had to read the files from the Docker image and those were not available to GUIs like the Keplr wallet.
-
-So as of https://github.com/Agoric/agoric-3-proposals/issues/5 we store the keys in SCM, in this directory that is conspicuous for testing only.

--- a/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/gov1.key
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/gov1.key
@@ -1,1 +1,0 @@
-such field health riot cost kitten silly tube flash wrap festival portion imitate this make question host bitter puppy wait area glide soldier knee

--- a/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/gov2.key
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/gov2.key
@@ -1,1 +1,0 @@
-physical immune cargo feel crawl style fox require inhale law local glory cheese bring swear royal spy buyer diesel field when task spin alley

--- a/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/gov3.key
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/gov3.key
@@ -1,1 +1,0 @@
-tackle hen gap lady bike explain erode midnight marriage wide upset culture model select dial trial swim wood step scan intact what card symptom

--- a/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/user1.key
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/user1.key
@@ -1,1 +1,0 @@
-spike siege world rather ordinary upper napkin voice brush oppose junior route trim crush expire angry seminar anchor panther piano image pepper chest alone

--- a/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/validator.key
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/keys_for_test_only/validator.key
@@ -1,1 +1,0 @@
-soap hub stick bomb dish index wing shield cruel board siren force glory assault rotate busy area topple resource okay clown wedding hint unhappy

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare_zero.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare_zero.sh
@@ -12,8 +12,17 @@ export CHAINID=agoriclocal
 agd init localnet --chain-id "$CHAINID"
 
 allaccounts=("gov1" "gov2" "gov3" "user1" "validator")
-for i in "${allaccounts[@]}"; do
-  cat "/usr/src/upgrade-test-scripts/keys_for_test_only/$i.key" | agd keys add $i --recover --keyring-backend=test 2>&1
+# WARNING: these mnemonics are purely for testing purposes, do not implement
+# features that depend on them in any way.
+allkeys=(
+  "such field health riot cost kitten silly tube flash wrap festival portion imitate this make question host bitter puppy wait area glide soldier knee"
+  "physical immune cargo feel crawl style fox require inhale law local glory cheese bring swear royal spy buyer diesel field when task spin alley"
+  "tackle hen gap lady bike explain erode midnight marriage wide upset culture model select dial trial swim wood step scan intact what card symptom"
+  "spike siege world rather ordinary upper napkin voice brush oppose junior route trim crush expire angry seminar anchor panther piano image pepper chest alone"
+  "soap hub stick bomb dish index wing shield cruel board siren force glory assault rotate busy area topple resource okay clown wedding hint unhappy"
+)
+for i in "${!allaccounts[@]}"; do
+  echo "${allkeys[$i]}" | agd keys add ${allaccounts[$i]} --recover --keyring-backend=test 2>&1
 done
 
 source /usr/src/upgrade-test-scripts/env_setup.sh

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare_zero.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_prepare_zero.sh
@@ -14,6 +14,7 @@ agd init localnet --chain-id "$CHAINID"
 allaccounts=("gov1" "gov2" "gov3" "user1" "validator")
 # WARNING: these mnemonics are purely for testing purposes, do not implement
 # features that depend on them in any way.
+# The mnemonics below corresponds to elements in `allaccounts` with matching indices
 allkeys=(
   "such field health riot cost kitten silly tube flash wrap festival portion imitate this make question host bitter puppy wait area glide soldier knee"
   "physical immune cargo feel crawl style fox require inhale law local glory cheese bring swear royal spy buyer diesel field when task spin alley"

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -28,8 +28,6 @@ ENV UPGRADE_TO=${to}
 # put env functions into shell environment
 RUN echo '. /usr/src/upgrade-test-scripts/env_setup.sh' >> ~/.bashrc
 
-# provide files with keys for testing
-COPY --link ./upgrade-test-scripts/keys_for_test_only /usr/src/upgrade-test-scripts/keys_for_test_only
 # copy scripts
 COPY --link --chmod=755 ./upgrade-test-scripts/env_setup.sh ./upgrade-test-scripts/run_prepare_zero.sh /usr/src/upgrade-test-scripts/
 SHELL ["/bin/bash", "-c"]

--- a/packages/synthetic-chain/src/lib/commonUpgradeHelpers.js
+++ b/packages/synthetic-chain/src/lib/commonUpgradeHelpers.js
@@ -137,8 +137,7 @@ export const getUser = async user => {
 };
 
 export const addUser = async user => {
-  const userKeyData = await agd.keys('add', user, '--keyring-backend=test');
-  await fsp.writeFile(`/usr/src/upgrade-test-scripts-keys_for_test_only/${user}.key`, userKeyData.mnemonic);
+  await agd.keys('add', user, '--keyring-backend=test');
 
   const userAddress = await getUser(user);
   return userAddress;


### PR DESCRIPTION
Closes: #139 

With the [workaround](https://github.com/Agoric/agoric-3-proposals/issues/136#issuecomment-2034174218) suggested by @gacogo, we no longer need to persist the mnemonics on disk. This PR removes the mnemonics on disk.