### PR TITLE
fix Node binary incompatibility

### DIFF
--- a/packages/synthetic-chain/src/cli/doctor.ts
+++ b/packages/synthetic-chain/src/cli/doctor.ts
@@ -35,7 +35,11 @@ const fixupProposal = (proposal: ProposalInfo) => {
 
       // refresh install
       execSync('rm -rf node_modules', { cwd: proposalPath });
-      execSync('yarn install', { cwd: proposalPath });
+      // install to update yarn.lock and get importable typed modules but
+      // skip building because the proposal never runs on the local filesystem.
+      // Without this the local environment may install binaries (e.g. better_sqlite3.node)
+      // that fail when mounted in the Docker environment by the test debug mode.
+      execSync('yarn install --mode=skip-build', { cwd: proposalPath });
     }
   }
 };


### PR DESCRIPTION
closes: #151 

# Test plan

I ran the updated doctor locally and confirmed there's no `.node` file.

I haven't yet tested with `test --debug` because my env is running into a different problem missing `--no-validate`. @Chris-Hibbert can you confirm this fixes #151? (e.g. copy this change `a3p-integration/node_modules/@agoric/synthetic-chain/dist/cli/cli.js` then run `yarn doctor` and then `yarn test --debug -m upgrade-next`)