### PR TITLE
WIP feat: reduce number of online vats

### DIFF
--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -184,6 +184,15 @@ ENTRYPOINT ./run_test.sh ${path}
     return `
 # LAST
 FROM ${useImage} as latest
+
+# Patching SwingSet to reduce the number of online vats
+COPY ./patches/min-vats-online.patch /usr/src/agoric-sdk/
+WORKDIR /usr/src/agoric-sdk/
+RUN git apply min-vats-online.patch
+WORKDIR /usr/src/agoric-sdk/packages/cosmic-swingset
+RUN make build
+
+WORKDIR /usr/src/upgrade-test-scripts
 `;
   },
 };

--- a/patches/min-vats-online.patch
+++ b/patches/min-vats-online.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/SwingSet/src/kernel/vat-warehouse.js b/packages/SwingSet/src/kernel/vat-warehouse.js
+index 327b74fd4..c6d6668bb 100644
+--- a/packages/SwingSet/src/kernel/vat-warehouse.js
++++ b/packages/SwingSet/src/kernel/vat-warehouse.js
+@@ -243,7 +243,7 @@ export function makeVatWarehouse({
+   panic,
+   warehousePolicy,
+ }) {
+-  const { maxVatsOnline = 50, restartWorkerOnSnapshot = true } =
++  const { maxVatsOnline = 5, restartWorkerOnSnapshot = true } =
+     warehousePolicy || {};
+   // Often a large contract evaluation is among the first few deliveries,
+   // so let's do a snapshot after just a few deliveries.


### PR DESCRIPTION
Reducing maxVatsOnline to only 5 online vats to reduce the load on the system that is running this container.

Testing:
Tested locally to see if this SwingSet change works without a3p. Now, with PR, trying to build an image in the CI to test.