### PR TITLE
fix: Update the killAgd "wait for pid" behavior

### DIFF
--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -100,7 +100,8 @@ killAgd() {
   AGD_PID=$(cat $HOME/.agoric/agd.pid)
   kill $AGD_PID
   rm $HOME/.agoric/agd.pid
-  wait $AGD_PID || true
+  # cf. https://stackoverflow.com/a/41613532
+  tail --pid=$AGD_PID -f /dev/null || true
 }
 
 provisionSmartWallet() {


### PR DESCRIPTION
The new approach works even when `agd` is not a child process of the current shell.

cf. https://github.com/Agoric/agoric-sdk/pull/9563/files#r1649820976