### PR TITLE
fix lint and getInstanceBoardId type

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": {
     "synthetic-chain": "dist/cli/cli.js"

--- a/packages/synthetic-chain/src/lib/commonUpgradeHelpers.ts
+++ b/packages/synthetic-chain/src/lib/commonUpgradeHelpers.ts
@@ -122,7 +122,7 @@ export const calculateWalletState = async (
 
 export const executeOffer = async (
   address: string,
-  offerPromise: Promise<string>,
+  offerPromise: string | Promise<string>,
 ) => {
   const offerPath = await mkTemp('agops.XXX');
   const offer = await offerPromise;

--- a/packages/synthetic-chain/src/lib/econHelpers.js
+++ b/packages/synthetic-chain/src/lib/econHelpers.js
@@ -7,9 +7,16 @@ import { queryVstorage, getQuoteBody, getInstanceBoardId } from './vstorage.js';
 const ORACLE_ADDRESSES = [GOV1ADDR, GOV2ADDR, GOV3ADDR];
 
 // TODO return the id of the new vault so subsequent commands can use it
+/**
+ *
+ * @param {string} address
+ * @param {string} mint
+ * @param {string} collateral
+ */
 export const openVault = (address, mint, collateral) => {
   return executeOffer(
     address,
+    // @ts-expect-error could return string[] but not in this case
     agops.vaults('open', '--wantMinted', mint, '--giveCollateral', collateral),
   );
 };
@@ -40,12 +47,14 @@ export const adjustVault = (address, vaultId, vaultParams) => {
     params = [...params, '--giveMinted', vaultParams.giveMinted];
   }
 
+  // @ts-expect-error could return string[] but not in this case
   return executeOffer(address, agops.vaults(...params));
 };
 
 export const closeVault = (address, vaultId, mint) => {
   return executeOffer(
     address,
+    // @ts-expect-error could return string[] but not in this case
     agops.vaults(
       'close',
       '--vaultId',

--- a/packages/synthetic-chain/src/lib/vat-status.js
+++ b/packages/synthetic-chain/src/lib/vat-status.js
@@ -37,6 +37,7 @@ const makeSwingstore = db => {
   const sql = dbTool(db);
 
   /** @param {string} key */
+  // @ts-expect-error sqlite typedefs
   const kvGet = key => sql.get`select * from kvStore where key = ${key}`.value;
   /** @param {string} key */
   const kvGetJSON = key => JSON.parse(kvGet(key));
@@ -77,6 +78,7 @@ export const getVatDetails = async vatName => {
   const vatInfo = kStore.lookupVat(vatID);
 
   const source = vatInfo.source();
+  // @ts-expect-error sqlite typedefs
   const { incarnation } = vatInfo.currentSpan();
   return { vatName, vatID, incarnation, ...source };
 };

--- a/packages/synthetic-chain/src/lib/vstorage.js
+++ b/packages/synthetic-chain/src/lib/vstorage.js
@@ -4,12 +4,17 @@ import { agd } from './cliHelper.js';
 const { freeze: harden } = Object; // XXX
 
 // from '@agoric/internal/src/lib-chainStorage.js';
+/** @type {(cell: unknown) => cell is { blockHeight: number;values: unknown[] }} cell */
 const isStreamCell = cell =>
-  cell &&
-  typeof cell === 'object' &&
-  Array.isArray(cell.values) &&
-  typeof cell.blockHeight === 'string' &&
-  /^0$|^[1-9][0-9]*$/.test(cell.blockHeight);
+  !!(
+    cell &&
+    typeof cell === 'object' &&
+    'values' in cell &&
+    Array.isArray(cell.values) &&
+    'blockHeight' in cell &&
+    typeof cell.blockHeight === 'string' &&
+    /^0$|^[1-9][0-9]*$/.test(cell.blockHeight)
+  );
 harden(isStreamCell);
 
 /**
@@ -37,10 +42,12 @@ export const extractStreamCellValue = (data, index = -1) => {
 };
 harden(extractStreamCellValue);
 
+/** @param {string} path */
 export const queryVstorage = path =>
   agd.query('vstorage', 'data', '--output', 'json', path);
 
 // XXX use endo/marshal?
+/** @param {string} path */
 export const getQuoteBody = async path => {
   const queryOut = await queryVstorage(path);
 
@@ -51,7 +58,7 @@ export const getQuoteBody = async path => {
 /**
  *
  * @param {string} instanceName
- * @returns {string | null} boardId of the named instance in agoricNames
+ * @returns {Promise<string | null>} boardId of the named instance in agoricNames
  */
 export const getInstanceBoardId = async instanceName => {
   const instanceRec = await queryVstorage(`published.agoricNames.instance`);

--- a/packages/synthetic-chain/tsconfig.json
+++ b/packages/synthetic-chain/tsconfig.json
@@ -2,8 +2,9 @@
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
         "allowJs": true,
-        "checkJs": false, // opt in
+        "checkJs": true,
         "strict": true,
+        "noImplicitAny": false,
         "maxNodeModuleJsDepth": 2,
         "module": "ES2022",
         "moduleResolution": "Node",


### PR DESCRIPTION
`getInstanceBoardId` had the wrong return type declared. This fixes that and updates `tsconfig` to check all JS so it doesn't happen again.

I published this as 0.2.1. Any changes requested I'll roll into 0.2.2.