### PR TITLE
chore: have bankSend accept `from` argument set to default as validator address

### DIFF
--- a/packages/synthetic-chain/src/lib/agd-lib.ts
+++ b/packages/synthetic-chain/src/lib/agd-lib.ts
@@ -133,11 +133,15 @@ export const makeAgd = ({
   return make();
 };
 
-export const bankSend = (addr: string, wanted: string) => {
+export const bankSend = (
+  addr: string,
+  wanted: string,
+  from: string = VALIDATORADDR,
+) => {
   const chain = ['--chain-id', CHAINID];
-  const from = ['--from', VALIDATORADDR];
+  const fromArg = ['--from', from];
   const testKeyring = ['--keyring-backend', 'test'];
-  const noise = [...from, ...chain, ...testKeyring, '--yes'];
+  const noise = [...fromArg, ...chain, ...testKeyring, '--yes'];
 
-  return agd.tx('bank', 'send', VALIDATORADDR, addr, wanted, ...noise);
+  return agd.tx('bank', 'send', from, addr, wanted, ...noise);
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please delete the sections below that aren pertinent to your PR
and then fulfill the remaining checklist items before merging.
-->

Closes #187 
Refs: https://github.com/Agoric/BytePitchPartnerEng/issues/27

## tooling improvements
Improve `bankSend` to accept a parameter as `from`. Set it to validator account by default so it won't break existing usage.


