### PR TITLE
chore(synthetic-chain): Improve env_setup.sh function output

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": "dist/cli/cli.js",
   "main": "./dist/lib/index.js",

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -143,22 +143,23 @@ wait_for_bootstrap() {
   echo "done"
 }
 
+# `waitForBlock $n` waits for at least $n (default 1) new blocks to be produced.
 waitForBlock() (
-  echo "waiting for block..."
-  times=${1:-1}
-  echo "$times"
-  for ((i = 1; i <= times; i++)); do
-    b1=$(wait_for_bootstrap)
+  n=${1:-1}
+  echo "waitForBlock waiting for $n new block(s)..."
+  h0=$(wait_for_bootstrap)
+  lastHeight="$h0"
+  for ((i = 1; i <= n; i++)); do
     while true; do
-      b2=$(wait_for_bootstrap)
-      if [[ "$b1" != "$b2" ]]; then
-        echo "block produced"
+      sleep 1
+      currentHeight=$(wait_for_bootstrap)
+      if [[ "$currentHeight" != "$lastHeight" ]]; then
+        echo "waitForBlock saw new height $currentHeight"
+        lastHeight="$currentHeight"
         break
       fi
-      sleep 1
     done
   done
-  echo "done"
 )
 
 fail() {

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -106,16 +106,15 @@ killAgd() {
 provisionSmartWallet() {
   addr="$1"
   amount="$2"
-  echo "funding $addr"
+  echo "provisionSmartWallet funding $addr"
   # shellcheck disable=SC2086
   agd tx bank send "validator" "$addr" "$amount" $SIGN_BROADCAST_OPTS
   waitForBlock
-  echo "provisioning $addr"
+  echo "provisionSmartWallet provisioning $addr"
   # shellcheck disable=SC2086
   agd tx swingset provision-one my-wallet "$addr" SMART_WALLET --from="$addr" $SIGN_BROADCAST_OPTS
-  echo "Waiting for wallet $addr to reach vstorage"
+  echo "provisionSmartWallet waiting five blocks for $addr wallet to reach vstorage"
   waitForBlock 5
-  echo "Reading $addr from vstorage"
   agoric wallet show --from "$addr"
 }
 

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -90,7 +90,6 @@ startAgd() {
   AGD_PID=$!
   echo $AGD_PID >$HOME/.agoric/agd.pid
   wait_for_bootstrap
-  echo "Bootstrap reached, wait two more blocks for race conditions to settle"
   waitForBlock 2
   echo "startAgd() done"
 }

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -145,10 +145,11 @@ wait_for_bootstrap() {
 
 # `waitForBlock $n` waits for at least $n (default 1) new blocks to be produced.
 waitForBlock() (
-  n=${1:-1}
+  local n=${1:-1}
   echo "waitForBlock waiting for $n new block(s)..."
-  h0=$(wait_for_bootstrap)
-  lastHeight="$h0"
+  local h0=$(wait_for_bootstrap)
+  local lastHeight="$h0"
+  local currentHeight
   for ((i = 1; i <= n; i++)); do
     while true; do
       sleep 1

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -120,7 +120,6 @@ provisionSmartWallet() {
 
 # XXX designed for ag0, others start well above height 1
 wait_for_bootstrap() {
-  echo "waiting for bootstrap..."
   endpoint="localhost"
   while true; do
     if json=$(curl -s --fail -m 15 "$endpoint:26657/status"); then
@@ -138,7 +137,6 @@ wait_for_bootstrap() {
     fi
     sleep 2
   done
-  echo "done"
 }
 
 # `waitForBlock $n` waits for at least $n (default 1) new blocks to be produced.

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -198,10 +198,9 @@ export SIGN_BROADCAST_OPTS="--keyring-backend=test --chain-id=$CHAINID \
 		--yes --broadcast-mode block --from validator"
 
 voteLatestProposalAndWait() {
-  echo "start voteLatestProposalAndWait()"
   waitForBlock
   proposal=$($binary q gov proposals -o json | jq -r '.proposals | last | if .proposal_id == null then .id else .proposal_id end')
-  echo "Latest proposal: $proposal"
+  echo "voteLatestProposalAndWait latest proposal $proposal"
   waitForBlock
   # shellcheck disable=SC2086
   $binary tx gov deposit "$proposal" 50000000ubld $SIGN_BROADCAST_OPTS
@@ -210,21 +209,22 @@ voteLatestProposalAndWait() {
   $binary tx gov vote "$proposal" yes $SIGN_BROADCAST_OPTS
   waitForBlock
 
-  echo "Voted in proposal $proposal"
+  echo "voteLatestProposalAndWait voted yes for proposal $proposal"
   while true; do
     json=$($binary q gov proposal "$proposal" -ojson)
     status=$(echo "$json" | jq -r .status)
     case $status in
     PROPOSAL_STATUS_PASSED)
+      echo "voteLatestProposalAndWait proposal $proposal passed"
       break
       ;;
     PROPOSAL_STATUS_REJECTED | PROPOSAL_STATUS_FAILED)
-      echo "Proposal did not pass (status=$status)"
+      echo "voteLatestProposalAndWait proposal $proposal did not pass (status=$status)"
       echo "$json" | jq .
       exit 1
       ;;
     *)
-      echo "Waiting for proposal to pass (status=$status)"
+      echo "voteLatestProposalAndWait waiting for proposal $proposal to pass (status=$status)"
       sleep 1
       ;;
     esac


### PR DESCRIPTION
Make CI logs more readable by:
* prefixing lines with "waitForBlock"/"voteLatestProposalAndWait"/etc.
* always including details (iteration count, observed block height, proposal id, etc.)
* omitting output that doesn't convey new information "done", "reading", etc.)

## @agoric/synthetic-chain library
- [x] passes CI
- [x] bump patch version
- [x] publish