### PR TITLE
chore(synthetic-chain): Improve JS waitForBlock output

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": "dist/cli/cli.js",
   "main": "./dist/lib/index.js",

--- a/packages/synthetic-chain/src/lib/commonUpgradeHelpers.ts
+++ b/packages/synthetic-chain/src/lib/commonUpgradeHelpers.ts
@@ -32,22 +32,20 @@ const waitForBootstrap = async (): Promise<number> => {
   }
 };
 
-export const waitForBlock = async (times = 1) => {
-  console.log(times);
-  let time = 0;
-  while (time < times) {
-    const block1 = await waitForBootstrap();
+export const waitForBlock = async (n = 1) => {
+  console.log(`waitForBlock waiting for ${n} new block(s)...`);
+  const h0 = await waitForBootstrap();
+  let lastHeight = h0;
+  for (let i = 0; i < n; i += 1) {
     while (true) {
-      const block2 = await waitForBootstrap();
-
-      if (block1 !== block2) {
-        console.log('block produced');
+      await new Promise(r => setTimeout(r, 1000));
+      const currentHeight = await waitForBootstrap();
+      if (currentHeight !== lastHeight) {
+        console.log(`waitForBlock saw new height ${currentHeight}`);
+        lastHeight = currentHeight;
         break;
       }
-
-      await new Promise(r => setTimeout(r, 1000));
     }
-    time += 1;
   }
 };
 


### PR DESCRIPTION
Duplicates d1ba3207b5511f8620d016b9d4440c3869127bc1 in the JS version of `waitForBlock`

## @agoric/synthetic-chain library
- [x] passes CI
- [x] bump patch version
- [x] publish