### PR TITLE
chore(synthetic-chain): Replace bare block height output in startAgd

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": "dist/cli/cli.js",
   "main": "./dist/lib/index.js",

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -89,7 +89,7 @@ startAgd() {
   agd start --log_level warn "$@" &
   AGD_PID=$!
   echo $AGD_PID >$HOME/.agoric/agd.pid
-  wait_for_bootstrap
+  echo "startAgd() at height $(wait_for_bootstrap | tr '\n' ' ' | sed 's/ $//; s/ /... /g;')"
   waitForBlock 2
   echo "startAgd() done"
 }

--- a/packages/synthetic-chain/src/lib/core-eval.ts
+++ b/packages/synthetic-chain/src/lib/core-eval.ts
@@ -79,11 +79,8 @@ export const passCoreEvalProposal = async (
   for (const { name, bundles, evals } of bundleInfos) {
     console.log(
       name,
-      evals[0].script,
-      evals.length,
-      'eval',
-      bundles.length,
-      'bundles',
+      evals.map(record => record.script),
+      `(bundle count: ${bundles.length})`,
     );
   }
 
@@ -119,7 +116,7 @@ export const passCoreEvalProposal = async (
           await fsp.readFile(path.join(dir, fileName), 'utf8'),
         );
         const entry = await bundleEntry(bundle);
-        console.log(entry, fileName.slice(0, 'b1-12345'.length));
+        console.log(`${fileName.slice(0, 'b1-#####'.length)}...`, entry);
         assert(entry.compartment);
         assert(entry.module);
       }
@@ -190,7 +187,7 @@ export const passCoreEvalProposal = async (
     assert.equal(todo, done);
   });
 
-  await step('core eval proposal passes', async () => {
+  await step('ensure core eval proposal passes', async () => {
     const { agd, swingstore, config } = context;
     const from = agd.lookup(config.proposer);
     const { chainId, deposit } = config;
@@ -231,7 +228,10 @@ export const passCoreEvalProposal = async (
     assert.equal(result.code, 0);
 
     const detail = await voteLatestProposalAndWait(info.title);
-    console.log(detail.proposal_id, detail.voting_end_time, detail.status);
+    console.log(
+      `proposal ${detail.proposal_id} end ${detail.voting_end_time}`,
+      detail.status,
+    );
     assert.equal(detail.status, 'PROPOSAL_STATUS_PASSED');
   });
 };


### PR DESCRIPTION
```diff
 [n:upgrade-next] Starting agd
 ENV_SETUP starting
 ENV_SETUP finished
 startAgd()
 Loading slog sender modules: @agoric/telemetry/src/slog-file.js @agoric/telemetry/src/flight-recorder.js
 2024-11-20T18:04:43.558Z launch-chain: Launching SwingSet kernel
-1310
+startAgd() at height 1310
 waitForBlock waiting for 2 new block(s)...
 2024-11-20T18:05:02.654Z launch-chain: Launched SwingSet kernel
 2024-11-20T18:05:02.657Z block-manager: block 1310 begin
 2024-11-20T18:05:03.050Z block-manager: block 1310 commit
```

## @agoric/synthetic-chain library
- [x] passes CI
- [x] bump patch version
- [x] publish