### PR TITLE
Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Finally there is a `DEFAULT` target which take the last `USE` image and sets its
 
 ### Naming
 
-Each proposal is defined as a subdirectory of `propoals`. E.g. `16:upgrade-8`.
+Each proposal is defined as a subdirectory of `proposals`. E.g. `16:upgrade-8`.
 
 The leading number is its number as submitted to the agoric-3 chain. These are viewable at https://bigdipper.live/agoric/proposals
 


### PR DESCRIPTION
### Pull Request Description

This PR fixes a typo in the `README.md` file under the "Naming" section. The word `propoaols` was corrected to `proposals`.

**Changes:**
- Corrected a typo in line 59 of `README.md`.

**Checklist:**
- [x] Review and approve the typo correction.
- [x] Verify no additional issues in the `README.md`.

This change ensures clarity and consistency in documentation. No functional impact on the project. Ready for review and merge.
<img width="553" alt="image" src="https://github.com/user-attachments/assets/ae68ff72-ca65-4787-b083-5d4d1e573d64">
