### PR TITLE
Fixed Typo in Container Registry Address Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ docker run ghcr.io/agoric/agoric-3-proposals:latest
 Or locally,
 
 ```sh
-docker build -t ghrc.io/agoric/agoric-3-proposals:dev .
-docker run  ghrc.io/agoric/agoric-3-proposals:dev
+docker build -t ghcr.io/agoric/agoric-3-proposals:dev .
+docker run  ghcr.io/agoric/agoric-3-proposals:dev
 ```
 
 ## Future work


### PR DESCRIPTION
### Description:

While reviewing the documentation in the **Images** section, I found a typo in the container registry address. The original commands contained:

```text
docker build -t ghrc.io/agoric/agoric-3-proposals:dev .
docker run  ghrc.io/agoric/agoric-3-proposals:dev
```

**Issue:** The address `ghrc.io` is incorrect and does not point to a valid container registry. The correct domain is `ghcr.io`, which is GitHub's official container registry.

**Fix:** The corrected commands are as follows:

```sh
docker build -t ghcr.io/agoric/agoric-3-proposals:dev .
docker run  ghcr.io/agoric/agoric-3-proposals:dev
```

This fix ensures that the commands work properly by pointing to the correct container registry address, preventing errors when attempting to build or run the image.
