### PR TITLE
feat: Prepare test hook

### DIFF
--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -25,9 +25,6 @@ export GOV3ADDR=$($binary keys show gov3 -a --keyring-backend="test")
 export VALIDATORADDR=$($binary keys show validator -a --keyring-backend="test")
 export USER1ADDR=$($binary keys show user1 -a --keyring-backend="test")
 
-export PID_FILE="$HOME/.agoric/agd.pid"
-export STATUS_FILE="$HOME/.agoric/last_observed_status"
-
 if [[ "$binary" == "agd" ]]; then
   configdir=/usr/src/agoric-sdk/packages/vm-config
   # Check specifically for package.json because the directory may persist in the file system
@@ -83,18 +80,6 @@ await_agd_startable() {
   fi
 }
 
-save_latest_node_info() {
-  PID="$(cat "$PID_FILE")"
-
-  if ps --pid "$PID" > /dev/null
-  then
-    NODE_STATUS="$(agd status)"
-    echo "$NODE_STATUS" > "$STATUS_FILE"
-  else
-    echo "[FATAL] Chain process not running"
-  fi
-}
-
 startAgd() {
   echo "startAgd()"
 
@@ -103,7 +88,7 @@ startAgd() {
 
   agd start --log_level warn "$@" &
   AGD_PID=$!
-  echo $AGD_PID > "$PID_FILE"
+  echo $AGD_PID >$HOME/.agoric/agd.pid
   echo "startAgd() at height $(wait_for_bootstrap | tr '\n' ' ' | sed 's/ $//; s/ /... /g;')"
   waitForBlock 2
   echo "startAgd() done"
@@ -111,10 +96,9 @@ startAgd() {
 
 killAgd() {
   echo "killAgd()"
-  save_latest_node_info
-  AGD_PID=$(cat "$PID_FILE")
+  AGD_PID=$(cat $HOME/.agoric/agd.pid)
   kill $AGD_PID
-  rm "$PID_FILE"
+  rm $HOME/.agoric/agd.pid
   # cf. https://stackoverflow.com/a/41613532
   tail --pid=$AGD_PID -f /dev/null || true
 }

--- a/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/env_setup.sh
@@ -25,6 +25,9 @@ export GOV3ADDR=$($binary keys show gov3 -a --keyring-backend="test")
 export VALIDATORADDR=$($binary keys show validator -a --keyring-backend="test")
 export USER1ADDR=$($binary keys show user1 -a --keyring-backend="test")
 
+export PID_FILE="$HOME/.agoric/agd.pid"
+export STATUS_FILE="$HOME/.agoric/last_observed_status"
+
 if [[ "$binary" == "agd" ]]; then
   configdir=/usr/src/agoric-sdk/packages/vm-config
   # Check specifically for package.json because the directory may persist in the file system
@@ -80,6 +83,18 @@ await_agd_startable() {
   fi
 }
 
+save_latest_node_info() {
+  PID="$(cat "$PID_FILE")"
+
+  if ps --pid "$PID" > /dev/null
+  then
+    NODE_STATUS="$(agd status)"
+    echo "$NODE_STATUS" > "$STATUS_FILE"
+  else
+    echo "[FATAL] Chain process not running"
+  fi
+}
+
 startAgd() {
   echo "startAgd()"
 
@@ -88,7 +103,7 @@ startAgd() {
 
   agd start --log_level warn "$@" &
   AGD_PID=$!
-  echo $AGD_PID >$HOME/.agoric/agd.pid
+  echo $AGD_PID > "$PID_FILE"
   echo "startAgd() at height $(wait_for_bootstrap | tr '\n' ' ' | sed 's/ $//; s/ /... /g;')"
   waitForBlock 2
   echo "startAgd() done"
@@ -96,9 +111,10 @@ startAgd() {
 
 killAgd() {
   echo "killAgd()"
-  AGD_PID=$(cat $HOME/.agoric/agd.pid)
+  save_latest_node_info
+  AGD_PID=$(cat "$PID_FILE")
   kill $AGD_PID
-  rm $HOME/.agoric/agd.pid
+  rm "$PID_FILE"
   # cf. https://stackoverflow.com/a/41613532
   tail --pid=$AGD_PID -f /dev/null || true
 }

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_eval.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_eval.sh
@@ -30,3 +30,5 @@ fi
 
 echo "[$PROPOSAL] Eval completed. Running 10 blocks and exiting."
 waitForBlock 10
+
+killAgd

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_test.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_test.sh
@@ -24,13 +24,21 @@ echo '
  |_____| |_____|    |    |_____  |_____| |  |  | |______
 '
 
+source ./env_setup.sh
+
+cd /usr/src/proposals/"$PROPOSAL/" || fail "Proposal $PROPOSAL does not exist"
+
+if test -f prepare-test.sh
+then
+  echo "[$PROPOSAL] Running prepare-test.sh"
+  ./prepare-test.sh
+fi
+
 echo "[$PROPOSAL] Starting agd"
 
-source ./env_setup.sh
 startAgd
 
 echo "[$PROPOSAL] Running test.sh."
-cd /usr/src/proposals/"$PROPOSAL/" || fail "Proposal $PROPOSAL does not exist"
 ./test.sh
 
 echo "[$PROPOSAL] Testing completed."

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_test.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_test.sh
@@ -42,3 +42,5 @@ echo "[$PROPOSAL] Running test.sh."
 ./test.sh
 
 echo "[$PROPOSAL] Testing completed."
+
+killAgd

--- a/packages/synthetic-chain/public/upgrade-test-scripts/run_use.sh
+++ b/packages/synthetic-chain/public/upgrade-test-scripts/run_use.sh
@@ -41,3 +41,5 @@ cd "$PROPOSAL_DIR"
 
 echo "[$PROPOSAL] Actions completed. Running for a few blocks and exiting."
 waitForBlock 5
+
+killAgd

--- a/packages/synthetic-chain/src/cli/build.ts
+++ b/packages/synthetic-chain/src/cli/build.ts
@@ -79,7 +79,17 @@ export const buildProposalSubmissions = (proposals: ProposalInfo[]) => {
  * @param [dry] - Whether to skip building and just print the build config.
  */
 export const bakeTarget = (target: string, dry = false) => {
-  const cmd = `docker buildx bake --load ${target} ${dry ? '--print' : ''}`;
+  const cmd = [
+    'docker',
+    'buildx',
+    'bake',
+    `--load "${target}"`,
+    dry && '--print',
+    process.env.DOCKER_PROGRESS_FORMAT &&
+      `--progress "${process.env.DOCKER_PROGRESS_FORMAT}"`,
+  ]
+    .filter(Boolean)
+    .join(' ');
   console.log(cmd);
   execSync(cmd, { stdio: 'inherit' });
 };


### PR DESCRIPTION
closes #xxxx

## image building process
- Enables a hook `prepare-test` which can be used to run commands before starting the tests
- Saves the last known block height in a local file before killing the `agd` process
- Adds missing `killAgd` in stages missing this function call

## @agoric/synthetic-chain library

Enables [docker progress logs verbosity](https://docs.docker.com/reference/cli/docker/buildx/build/#progress) through environmental variable `DOCKER_PROGRESS_FORMAT`. The `plain` progress format is handy for debugging.
