### PR TITLE
copy 'test' files only in TEST stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ All proposals then have two additional stages:
 - `USE` Perform actions to update the chain state, to persist through the chain history. E.g. adding a vault that will be tested again in the future.
 - `TEST` Test the chain state and perform new actions that should not be part of history. E.g. adding a contract that never was on Mainnet.
 
-The `TEST` stage does not RUN as part of the build. It only defines the ENTRYPOINT and CI runs them all.
+The `TEST` stage does not RUN as part of the build. It only copies test files into the image and defines the ENTRYPOINT. CI runs those entrypoints to execute the tests.
+(Note that some other phases use tests too, for example to pre-test, so files like `pre.test.js` are always copied. Only `test.sh` and a `test` dir are excluded from stages before TEST.)
 
 The `USE` stage is built into images that are pushed to the image repository. These can be used by release branches to source a particular state of the synthetic chain.
 

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -10,6 +10,9 @@ import {
   type SoftwareUpgradePackage,
 } from './proposals.js';
 
+// We need this unstable syntax for the `COPY --exclude` feature.
+const syntaxPragma = '# syntax=docker/dockerfile:1.7-labs';
+
 /**
  * Templates for Dockerfile stages
  */
@@ -211,7 +214,7 @@ export function writeDockerfile(
 ) {
   // Each stage tests something about the left argument and prepare an upgrade to the right side (by passing the proposal and halting the chain.)
   // The upgrade doesn't happen until the next stage begins executing.
-  const blocks: string[] = ['# syntax=docker/dockerfile:1.4'];
+  const blocks: string[] = [syntaxPragma];
 
   let previousProposal: ProposalInfo | null = null;
 

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -75,7 +75,7 @@ ENV \
     UPGRADE_INFO=${JSON.stringify(encodeUpgradeInfo(upgradeInfo))} \
     SKIP_PROPOSAL_VALIDATION=${skipProposalValidation}
 
-COPY --link --chmod=755 ./proposals/${path} /usr/src/proposals/${path}
+COPY --exclude=test --exclude=test.sh --link --chmod=755 ./proposals/${path} /usr/src/proposals/${path}
 COPY --link --chmod=755 ./upgrade-test-scripts/env_setup.sh ./upgrade-test-scripts/run_prepare.sh ./upgrade-test-scripts/start_to_to.sh /usr/src/upgrade-test-scripts/
 WORKDIR /usr/src/upgrade-test-scripts
 SHELL ["/bin/bash", "-c"]
@@ -100,7 +100,7 @@ FROM ghcr.io/agoric/agoric-sdk:${sdkImageTag} as execute-${proposalName}
 WORKDIR /usr/src/upgrade-test-scripts
 
 # base is a fresh sdk image so set up the proposal and its dependencies
-COPY --link --chmod=755 ./proposals/${path} /usr/src/proposals/${path}
+COPY --exclude=test --exclude=test.sh --link --chmod=755 ./proposals/${path} /usr/src/proposals/${path}
 COPY --link --chmod=755 ./upgrade-test-scripts/env_setup.sh ./upgrade-test-scripts/run_execute.sh  ./upgrade-test-scripts/start_to_to.sh ./upgrade-test-scripts/install_deps.sh /usr/src/upgrade-test-scripts/
 RUN --mount=type=cache,target=/root/.yarn ./install_deps.sh ${path}
 
@@ -122,7 +122,7 @@ RUN ./run_execute.sh ${planName}
 # EVAL ${proposalName}
 FROM use-${lastProposal.proposalName} as eval-${proposalName}
 
-COPY --link --chmod=755 ./proposals/${path} /usr/src/proposals/${path}
+COPY --exclude=test --exclude=test.sh --link --chmod=755 ./proposals/${path} /usr/src/proposals/${path}
 
 WORKDIR /usr/src/upgrade-test-scripts
 
@@ -167,6 +167,11 @@ ENTRYPOINT ./start_agd.sh
     return `
 # TEST ${proposalName}
 FROM use-${proposalName} as test-${proposalName}
+
+# Previous stages copied excluding test files (see COPY above). It would be good
+# to copy only missing files, but there may be none. Fortunately, copying extra
+# does not invalidate other images because nothing depends on this layer.
+COPY --link --chmod=755 ./proposals/${path} /usr/src/proposals/${path}
 
 WORKDIR /usr/src/upgrade-test-scripts
 


### PR DESCRIPTION
Closes: #115

## image building process

This omits `test*` from non-test images. Presumably no other stages depend on "test*" files. CI passing here is evidence of that in the a3p images. If any are affected in downsteam repos we can correct them.
