### PR TITLE
test: replace tsimp with ts-blank-space

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -50,8 +50,7 @@
     },
     "nodeArguments": [
       "--import=ts-blank-space/register"
-    ],
-    "timeout": "30s"
+    ]
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -33,7 +33,7 @@
     "@types/glob": "^8.1.0",
     "@types/node": "^18.19.50",
     "ava": "^6.2.0",
-    "tsimp": "^2.0.12",
+    "ts-blank-space": "^0.5.0",
     "tsup": "^8.3.5",
     "typescript": "^5.7.3"
   },
@@ -49,7 +49,7 @@
       "HOME": "/tmp/fake-home"
     },
     "nodeArguments": [
-      "--import=tsimp"
+      "--import=ts-blank-space/register"
     ],
     "timeout": "30s"
   },

--- a/packages/synthetic-chain/src/lib/agd-lib.ts
+++ b/packages/synthetic-chain/src/lib/agd-lib.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { ExecFileSyncOptionsWithStringEncoding } from 'node:child_process';
+import type { ExecFileSyncOptionsWithStringEncoding } from 'node:child_process';
 import { CHAINID, VALIDATORADDR } from './constants.js';
 import { agd } from './cliHelper.js';
 

--- a/packages/synthetic-chain/src/lib/commonUpgradeHelpers.ts
+++ b/packages/synthetic-chain/src/lib/commonUpgradeHelpers.ts
@@ -1,4 +1,4 @@
-import { $, TemplateExpression } from 'execa';
+import { $, type TemplateExpression } from 'execa';
 import fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import { agd, agoric, agops } from './cliHelper.js';

--- a/packages/synthetic-chain/src/lib/core-eval-support.ts
+++ b/packages/synthetic-chain/src/lib/core-eval-support.ts
@@ -7,8 +7,7 @@ import { Far, makeMarshal, makeTranslationTable } from './unmarshal.js';
 // or at least allow caller to supply authority.
 import { agoric } from './cliHelper.js';
 import { getISTBalance, mintIST } from './econHelpers.js';
-import { ExecutionContext } from 'ava';
-import { StaticConfig } from './core-eval.js';
+import { type StaticConfig } from './core-eval.js';
 import path from 'node:path';
 
 // move to unmarshal.js?

--- a/packages/synthetic-chain/src/lib/core-eval.ts
+++ b/packages/synthetic-chain/src/lib/core-eval.ts
@@ -11,9 +11,8 @@ import { makeAgd } from './agd-lib.js';
 import { agoric } from './cliHelper.js';
 import { voteLatestProposalAndWait } from './commonUpgradeHelpers.js';
 import { dbTool } from './vat-status.js';
-import { type WebCache } from './webAsset.js';
 import {
-  BundleInfo,
+  type BundleInfo,
   bundleDetail,
   ensureISTForInstall,
   flags,

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@ __metadata:
     cosmjs-types: "npm:^0.9.0"
     execa: "npm:^9.5.2"
     glob: "npm:^11.0.0"
-    tsimp: "npm:^2.0.12"
+    ts-blank-space: "npm:^0.5.0"
     tsup: "npm:^8.3.5"
     typescript: "npm:^5.7.3"
   bin:
@@ -272,22 +272,6 @@ __metadata:
   version: 0.24.2
   resolution: "@esbuild/win32-x64@npm:0.24.2"
   conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@isaacs/cached@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@isaacs/cached@npm:1.0.1"
-  dependencies:
-    "@isaacs/catcher": "npm:^1.0.0"
-  checksum: 10c0/1c15dc2a60873f2c73f4b04ed59ecfc8d9679976ff09af1b5b45e7273a590a4f86a339cc4c785c2d22309277ca47293611af20dd7d41550cdcfb53e06a04ac65
-  languageName: node
-  linkType: hard
-
-"@isaacs/catcher@npm:^1.0.0, @isaacs/catcher@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "@isaacs/catcher@npm:1.0.4"
-  checksum: 10c0/d8b77e2c6b84a6301d390d0b2badea1b4a321f2e8ba662645b045efc42f20a54a6c760f3181fab4ed0d90da58f2cb084a93490a892c53b4da21ec05278b8ba4f
   languageName: node
   linkType: hard
 
@@ -1602,16 +1586,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:^3.1.1":
-  version: 3.3.0
-  resolution: "foreground-child@npm:3.3.0"
-  dependencies:
-    cross-spawn: "npm:^7.0.0"
-    signal-exit: "npm:^4.0.1"
-  checksum: 10c0/028f1d41000553fcfa6c4bb5c372963bf3d9bf0b1f25a87d1a6253014343fb69dfb1b42d9625d7cf44c8ba429940f3d0ff718b62105d4d4a4f6ef8ca0a53faa2
-  languageName: node
-  linkType: hard
-
 "fs-constants@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
@@ -2657,7 +2631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.1, pirates@npm:^4.0.6":
+"pirates@npm:^4.0.1":
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
   checksum: 10c0/00d5fa51f8dded94d7429700fb91a0c1ead00ae2c7fd27089f0c5b63e6eca36197fe46384631872690a66f390c5e27198e99006ab77ae472692ab9c2ca903f36
@@ -2877,18 +2851,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "rimraf@npm:6.0.1"
-  dependencies:
-    glob: "npm:^11.0.0"
-    package-json-from-dist: "npm:^1.0.0"
-  bin:
-    rimraf: dist/esm/bin.mjs
-  checksum: 10c0/b30b6b072771f0d1e73b4ca5f37bb2944ee09375be9db5f558fcd3310000d29dfcfa93cf7734d75295ad5a7486dc8e40f63089ced1722a664539ffc0c3ece8c6
-  languageName: node
-  linkType: hard
-
 "rollup@npm:^4.24.0":
   version: 4.30.1
   resolution: "rollup@npm:4.30.1"
@@ -3093,24 +3055,6 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
-  languageName: node
-  linkType: hard
-
-"sock-daemon@npm:^1.4.2":
-  version: 1.4.2
-  resolution: "sock-daemon@npm:1.4.2"
-  dependencies:
-    rimraf: "npm:^5.0.5"
-    signal-exit: "npm:^4.1.0"
-    socket-post-message: "npm:^1.0.3"
-  checksum: 10c0/1b5e0b02fdd8cd5454fc7de80557c11aac5d88085d0cee80ead08b8f4df5e3c0a4b50ebb2ae2113dab94f36dc88b5d3b7d4b1c2c8e53bbcfbddfc741abf3bd00
-  languageName: node
-  linkType: hard
-
-"socket-post-message@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "socket-post-message@npm:1.0.3"
-  checksum: 10c0/d3ffb51dad97754856aaa6709e036196f4b8b674f00366b71591ead122bcdbc073827f67d17c8b03c9a28c921b2c7cb277c581f6ca318d472034eae7afc169d1
   languageName: node
   linkType: hard
 
@@ -3416,31 +3360,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-blank-space@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "ts-blank-space@npm:0.5.0"
+  dependencies:
+    typescript: "npm:5.1.6 - 5.7.x"
+  checksum: 10c0/2e59aa7ed8f2cc2b1de14da2ff43b94ca4f10d62883691d3e7c3ebebb5ac3dfbbb088f822f752c6849009ab3f2b0dc4a1b7a3195efefcacbf07ed5edbff6bcf7
+  languageName: node
+  linkType: hard
+
 "ts-interface-checker@npm:^0.1.9":
   version: 0.1.13
   resolution: "ts-interface-checker@npm:0.1.13"
   checksum: 10c0/232509f1b84192d07b81d1e9b9677088e590ac1303436da1e92b296e9be8e31ea042e3e1fd3d29b1742ad2c959e95afe30f63117b8f1bc3a3850070a5142fea7
-  languageName: node
-  linkType: hard
-
-"tsimp@npm:^2.0.12":
-  version: 2.0.12
-  resolution: "tsimp@npm:2.0.12"
-  dependencies:
-    "@isaacs/cached": "npm:^1.0.1"
-    "@isaacs/catcher": "npm:^1.0.4"
-    foreground-child: "npm:^3.1.1"
-    mkdirp: "npm:^3.0.1"
-    pirates: "npm:^4.0.6"
-    rimraf: "npm:^6.0.1"
-    signal-exit: "npm:^4.1.0"
-    sock-daemon: "npm:^1.4.2"
-    walk-up-path: "npm:^4.0.0"
-  peerDependencies:
-    typescript: ^5.1.0
-  bin:
-    tsimp: dist/esm/bin.mjs
-  checksum: 10c0/c56c03a6a4df3ab5ebcefcc0b473992cbb7150173c331be6bda01670d5ae3965e65f30c42757cd391100a1c21485e167a05a350d875f41826b35c45008e5fac8
   languageName: node
   linkType: hard
 
@@ -3501,7 +3433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.7.3":
+"typescript@npm:5.1.6 - 5.7.x, typescript@npm:^5.7.3":
   version: 5.7.3
   resolution: "typescript@npm:5.7.3"
   bin:
@@ -3511,7 +3443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.1.6 - 5.7.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
   version: 5.7.3
   resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
@@ -3564,13 +3496,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
-  languageName: node
-  linkType: hard
-
-"walk-up-path@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "walk-up-path@npm:4.0.0"
-  checksum: 10c0/fabe344f91387d1d41df230af962ef18bf703dd4178006d55cd6412caacd187b54440002d4d53a982d4f7f0455567dcffb6d3884533c8b2268928eca3ebd8a19
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## @agoric/synthetic-chain library

This solves a test problem so doesn't need a release.

@usmanmani1122 reports that #214 changes caused the tests to hang and timeout because of this tsimp issue,
- https://github.com/avajs/ava/issues/3349

To solve that this PR replaces `tsimp` with `ts-blank-space`.