### PR TITLE
skip build in local yarn install

### DIFF
--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -20,21 +20,21 @@
     "node": "^18.19 || ^20.9"
   },
   "dependencies": {
-    "@endo/zip": "^1.0.7",
-    "better-sqlite3": "^11.8.0",
+    "@endo/zip": "^1.0.9",
+    "better-sqlite3": "^11.8.1",
     "chalk": "^5.4.1",
     "cosmjs-types": "^0.9.0",
     "execa": "^9.5.2",
-    "glob": "^11.0.0"
+    "glob": "^11.0.1"
   },
   "devDependencies": {
     "@agoric/cosmic-proto": "0.5.0-u18.5",
-    "@types/better-sqlite3": "^7.6.11",
+    "@types/better-sqlite3": "^7.6.12",
     "@types/glob": "^8.1.0",
     "@types/node": "^18.19.50",
     "ava": "^6.2.0",
-    "ts-blank-space": "^0.5.0",
-    "tsup": "^8.3.5",
+    "ts-blank-space": "^0.5.1",
+    "tsup": "^8.3.6",
     "typescript": "^5.7.3"
   },
   "ava": {

--- a/packages/synthetic-chain/package.json
+++ b/packages/synthetic-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/synthetic-chain",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Utilities to build a chain and test proposals atop it",
   "bin": "dist/cli/cli.js",
   "main": "./dist/lib/index.js",

--- a/packages/synthetic-chain/src/cli/doctor.ts
+++ b/packages/synthetic-chain/src/cli/doctor.ts
@@ -49,7 +49,11 @@ const fixupProposal = (proposal: ProposalInfo) => {
 
       // refresh install
       execSync('rm -rf node_modules', { cwd: proposalPath });
-      execSync('yarn install', { cwd: proposalPath });
+      // skip builds to prevent local native artifacts from accidentally being
+      // copied into the Docker image. The local environment never runs the
+      // proposal so the only artifacts that are necessary are the files that
+      // the JS IDE expects (e.g. for module resolution, types).
+      execSync('yarn install --mode=skip-build', { cwd: proposalPath });
     }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,18 +22,18 @@ __metadata:
   resolution: "@agoric/synthetic-chain@workspace:packages/synthetic-chain"
   dependencies:
     "@agoric/cosmic-proto": "npm:0.5.0-u18.5"
-    "@endo/zip": "npm:^1.0.7"
-    "@types/better-sqlite3": "npm:^7.6.11"
+    "@endo/zip": "npm:^1.0.9"
+    "@types/better-sqlite3": "npm:^7.6.12"
     "@types/glob": "npm:^8.1.0"
     "@types/node": "npm:^18.19.50"
     ava: "npm:^6.2.0"
-    better-sqlite3: "npm:^11.8.0"
+    better-sqlite3: "npm:^11.8.1"
     chalk: "npm:^5.4.1"
     cosmjs-types: "npm:^0.9.0"
     execa: "npm:^9.5.2"
-    glob: "npm:^11.0.0"
-    ts-blank-space: "npm:^0.5.0"
-    tsup: "npm:^8.3.5"
+    glob: "npm:^11.0.1"
+    ts-blank-space: "npm:^0.5.1"
+    tsup: "npm:^8.3.6"
     typescript: "npm:^5.7.3"
   bin:
     synthetic-chain: dist/cli/cli.js
@@ -93,10 +93,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@endo/zip@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "@endo/zip@npm:1.0.7"
-  checksum: 10c0/a1c0d155448ce877012b34c8fe8cd3a58de9eb807514c81cddeebb802ee8e552b27d8a9a40fab3f3e4c49e0cb7fea6902fa1dd12a23ff6f30b56161fc3edc1f8
+"@endo/zip@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "@endo/zip@npm:1.0.9"
+  checksum: 10c0/3fccea31bd5dad938a3b5f531454d3c49513892d6d5aba1f0af1034ff0ae54c3e28a346a9df08bd9e5201354acccd631e45c9c0e68fa2848a876a3919f3830dc
   languageName: node
   linkType: hard
 
@@ -583,12 +583,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/better-sqlite3@npm:^7.6.11":
-  version: 7.6.11
-  resolution: "@types/better-sqlite3@npm:7.6.11"
+"@types/better-sqlite3@npm:^7.6.12":
+  version: 7.6.12
+  resolution: "@types/better-sqlite3@npm:7.6.12"
   dependencies:
     "@types/node": "npm:*"
-  checksum: 10c0/6a7b8e5765f872404242ff9626edf4b4dd7974047144ba7254a59f4f1c196d05f8001323d0b526e8bbb3842bf541e341d74ca0164e50bd38fceaf3ef5d2a673d
+  checksum: 10c0/5367de7492e2c697aa20cc4024ba26210971d15f60c01ef691eddfbbfd39ccf9f80d5129fd7fd6c76c98804739325e23d2b156b0eac8f5a7665ba374a08ac1e7
   languageName: node
   linkType: hard
 
@@ -626,11 +626,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^18.19.50":
-  version: 18.19.50
-  resolution: "@types/node@npm:18.19.50"
+  version: 18.19.74
+  resolution: "@types/node@npm:18.19.74"
   dependencies:
     undici-types: "npm:~5.26.4"
-  checksum: 10c0/36e6bc9eb47213ce94a868dad9504465ad89fba6af9f7954e22bb27fb17a32ac495f263d0cf4fdaee74becd7b2629609a446ec8c2b59b7a07bd587567c8a4782
+  checksum: 10c0/365d9cc2af934965aa6a8471e24ae80add815c15dc094e42a320c57c1ea5416032f0b7ef6f23e32174c34811fbb8d89ea8eaa1396548610fbb8ba317b6e93fbf
   languageName: node
   linkType: hard
 
@@ -875,14 +875,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^11.8.0":
-  version: 11.8.0
-  resolution: "better-sqlite3@npm:11.8.0"
+"better-sqlite3@npm:^11.8.1":
+  version: 11.8.1
+  resolution: "better-sqlite3@npm:11.8.1"
   dependencies:
     bindings: "npm:^1.5.0"
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
-  checksum: 10c0/8dcebf674c47882662c423aa5c1de141082bec48fda8c0b9fe417151de666eb66ca893baaf5dd2336b271beb86d4582c0dcd632f5e4d3c5f4069faa46e2a6b56
+  checksum: 10c0/b6b1844f8ed5668080cc1e2a137656da756af406b616ffbd6139b230c906b9c0571bbdac53cd78cc1415689f5090d25daf95ea596ced0b9ad5e8be9b4a08662e
   languageName: node
   linkType: hard
 
@@ -1708,9 +1708,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "glob@npm:11.0.0"
+"glob@npm:^11.0.1":
+  version: 11.0.1
+  resolution: "glob@npm:11.0.1"
   dependencies:
     foreground-child: "npm:^3.1.0"
     jackspeak: "npm:^4.0.1"
@@ -1720,7 +1720,7 @@ __metadata:
     path-scurry: "npm:^2.0.0"
   bin:
     glob: dist/esm/bin.mjs
-  checksum: 10c0/419866015d8795258a8ac51de5b9d1a99c72634fc3ead93338e4da388e89773ab21681e494eac0fbc4250b003451ca3110bb4f1c9393d15d14466270094fdb4e
+  checksum: 10c0/2b32588be52e9e90f914c7d8dec32f3144b81b84054b0f70e9adfebf37cd7014570489f2a79d21f7801b9a4bd4cca94f426966bfd00fb64a5b705cfe10da3a03
   languageName: node
   linkType: hard
 
@@ -3360,12 +3360,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-blank-space@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "ts-blank-space@npm:0.5.0"
+"ts-blank-space@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "ts-blank-space@npm:0.5.1"
   dependencies:
     typescript: "npm:5.1.6 - 5.7.x"
-  checksum: 10c0/2e59aa7ed8f2cc2b1de14da2ff43b94ca4f10d62883691d3e7c3ebebb5ac3dfbbb088f822f752c6849009ab3f2b0dc4a1b7a3195efefcacbf07ed5edbff6bcf7
+  checksum: 10c0/fc7945dc3a241c607846c610b87843a295bef95f2877547da73b563eeafa2e65b8d2ec3416332aee630f438560425e9f823ca8c9e39eca8f06056653e8152e2c
   languageName: node
   linkType: hard
 
@@ -3376,9 +3376,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^8.3.5":
-  version: 8.3.5
-  resolution: "tsup@npm:8.3.5"
+"tsup@npm:^8.3.6":
+  version: 8.3.6
+  resolution: "tsup@npm:8.3.6"
   dependencies:
     bundle-require: "npm:^5.0.0"
     cac: "npm:^6.7.14"
@@ -3413,7 +3413,7 @@ __metadata:
   bin:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
-  checksum: 10c0/7794953cbc784b7c8f14c4898d36a293b815b528d3098c2416aeaa2b4775dc477132cd12f75f6d32737dfd15ba10139c73f7039045352f2ba1ea7e5fe6fe3773
+  checksum: 10c0/b8669bba2aafb8831832d7638792a20a101778a07ba971ea36fca47c27e7095fe0c91d29669d2fc0d17941138bc87245de1d0c4e5abf0ce5dfec7bf9eb76a5bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
_incidental_

## @agoric/synthetic-chain library

Some users were encountering errors with locally built deps being included in the Docker build, causing:
```
#  file proposals/n\:upgrade-next/node_modules/@agoric/synthetic-chain/node_modules/better-sqlite3/build/Release/better*
proposals/n:upgrade-next/node_modules/@agoric/synthetic-chain/node_modules/better-sqlite3/build/Release/better_sqlite3.node: Mach-O 64-bit bundle arm64
```

This changes the `yarn install` in `doctor` to skip builds scripts so that the native dep is not created locally.

It also bumps some deps for hygiene and bumps the version number for publishing. Once this is approved I'll publish.
