### PR TITLE
Check if the vat.terminated table is present before relying on it

### DIFF
--- a/packages/synthetic-chain/src/lib/vat-status.js
+++ b/packages/synthetic-chain/src/lib/vat-status.js
@@ -37,6 +37,7 @@ const makeSwingstoreTool = db => {
   /** @param {string} key */
   // @ts-expect-error sqlite typedefs
   const kvGet = key => sql.get`select * from kvStore where key = ${key}`.value;
+  const kvGetSafe = key => sql.get`select * from kvStore where key = ${key}`;
   /** @param {string} key */
   const kvGetJSON = key => JSON.parse(kvGet(key));
 
@@ -48,6 +49,10 @@ const makeSwingstoreTool = db => {
       currentSpan: () =>
         sql.get`select * from transcriptSpans where isCurrent = 1 and vatID = ${vatID}`,
       terminated: () => {
+        const t = kvGetSafe('vat.terminated');
+        if (!t) {
+          return false;
+        }
         const terminatedIDs = kvGetJSON('vat.terminated');
         return terminatedIDs.some(terminatedID => vatID === terminatedID);
       },


### PR DESCRIPTION
#218 tried to add the termination status of vats to their details, but missed the case when the table is not present. This checks first.

## tooling improvements

`getVatDetailsFromID`, `getIncarnation`, and `getDetailsMatchingVats` should all be robust now.