### PR TITLE
chore(synthetic-chain): Improve output for debugging `agd` invocations

### DIFF
--- a/.changeset/giant-jeans-jump.md
+++ b/.changeset/giant-jeans-jump.md
@@ -1,0 +1,5 @@
+---
+'@agoric/synthetic-chain': patch
+---
+
+Improve output for debugging `agd` invocations

--- a/packages/synthetic-chain/src/lib/agd-lib.ts
+++ b/packages/synthetic-chain/src/lib/agd-lib.ts
@@ -35,7 +35,17 @@ export const makeAgd = ({
     const exec = (
       args: string[],
       opts?: ExecFileSyncOptionsWithStringEncoding,
-    ) => execFileSync(agdBinary, args, opts).toString();
+    ) => {
+      console.warn(
+        '# invoking agd:',
+        ...[agdBinary, ...args].map(arg =>
+          arg.match(/[^a-zA-Z0-9,._+:@%/-]/)
+            ? `'${arg.replaceAll(`'`, `'\\''`)}'`
+            : arg,
+        ),
+      );
+      return execFileSync(agdBinary, args, opts).toString();
+    };
 
     const outJson = ['--output', 'json'];
 

--- a/packages/synthetic-chain/src/lib/cliHelper.ts
+++ b/packages/synthetic-chain/src/lib/cliHelper.ts
@@ -1,16 +1,23 @@
 import { $, execaCommand } from 'execa';
 import { BINARY, SDK_ROOT } from './constants.js';
+import type { Options as ExecaOptions } from 'execa';
 
 export const executeCommand = async (
   command: string,
   params: string[],
-  options = {},
+  options: Omit<
+    ExecaOptions,
+    'buffer' | 'encoding' | 'lines' | 'stdio' | 'stdout'
+  > = {},
 ) => {
-  const { stdout } = await execaCommand(
-    `${command} ${params.join(' ')}`,
-    options,
-  );
-  return stdout;
+  const invocation = `${command} ${params.join(' ')}`;
+  console.warn('# invoking:', invocation);
+  const result = await execaCommand(invocation, options);
+  if (!options.stderr) {
+    const { stderr } = result;
+    if (stderr) console.warn(stderr);
+  }
+  return result.stdout;
 };
 
 export const agd = {

--- a/packages/synthetic-chain/src/lib/core-eval-support.ts
+++ b/packages/synthetic-chain/src/lib/core-eval-support.ts
@@ -46,8 +46,8 @@ export const flags = (record: Record<string, string>): string[] => {
 };
 
 export const txAbbr = (tx: any) => {
-  const { txhash, code, height, gas_used } = tx;
-  return { txhash, code, height, gas_used };
+  const { txhash, codespace, code, height, gas_used } = tx;
+  return { txhash, codespace, code, height, gas_used };
 };
 
 export const loadedBundleIds = (swingstore: any) => {

--- a/packages/synthetic-chain/src/lib/core-eval.ts
+++ b/packages/synthetic-chain/src/lib/core-eval.ts
@@ -170,7 +170,7 @@ export const passCoreEvalProposal = async (
           ['swingset', 'install-bundle', `@${bundleRd}`],
           { from, chainId, yes: true },
         );
-        console.log(txAbbr(result));
+        console.log(result.code === 0 ? txAbbr(result) : result);
         assert.equal(result.code, 0);
 
         const info = await getContractInfo('bundles', { agoric, prefix: '' });


### PR DESCRIPTION
* Emit CLI commands to standard error
* Include `codespace` with `code` when dumping an abbreviated result
* Dump non-abbreviated result when there is a failure

## @agoric/synthetic-chain library

It's probably time to publish after this lands.

- [ ] passes CI
- [ ] bump patch version
- [ ] publish