### PR TITLE
docs (README.md): fix linl to proposals articul

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `USE` stage is built into images that are pushed to the image repository. Th
 
 Each proposal is defined as a subdirectory of `proposals`. E.g. `16:upgrade-8`.
 
-The leading number is its number as submitted to the agoric-3 chain. These are viewable at https://docs.agoric.com/guides/zoe/proposal.html#proposals
+The leading number is its number as submitted to the agoric-3 chain. These are viewable at https://agoric.explorers.guru/proposals
 
 The string after `:` is the local label for the proposal. It should be distinct, concise, and lowercase. (The string is used in the Dockerfile in a token that must be lowercase.)
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please delete the sections below that aren pertinent to your PR
and then fulfill the remaining checklist items before merging.
-->

Closes #

# adopt a passed proposal

When a proposal passes on agoric-3 Mainnet, it should be included in the history that this synthetic image tracks.

- [ ] before this PR, change any `fromTag` using `latest` (such as [a3p-integration](https://github.com/Agoric/agoric-sdk/blob/master/a3p-integration/package.json)) to use a fixed version (otherwise they will fail when this PR changes latest and they pick it up)
- [ ] before merging this PR, include a link to a PR that adopts its fromTag `use-${proposalName}` (where proposalName is the part of the agoric-3-proposals proposal directory name after the colon, cf. [a3p-integration/proposals](https://github.com/Agoric/agoric-sdk/tree/master/a3p-integration/proposals#how-to-revise-this-directory-after))
- [ ] after this PR merges, merge that other PR

## image building process

This should not affect other repos but be prepared that it might.

## @agoric/synthetic-chain library

These need to be published to be consumed in other apps. It's not yet on 1.0 so breaking changes are allowed, but please don't make them gratuitously.

- [ ] indicate in the PR description when you expect these to be published and by whom (it's currently a manual process)

## tooling improvements

As long as it passes CI it should be fine.
