### PR TITLE
fix: update dead link to Proposals Articul

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `USE` stage is built into images that are pushed to the image repository. Th
 
 Each proposal is defined as a subdirectory of `proposals`. E.g. `16:upgrade-8`.
 
-The leading number is its number as submitted to the agoric-3 chain. These are viewable at https://bigdipper.live/agoric/proposals
+The leading number is its number as submitted to the agoric-3 chain. These are viewable at https://agoric.explorers.guru/proposals
 
 The string after `:` is the local label for the proposal. It should be distinct, concise, and lowercase. (The string is used in the Dockerfile in a token that must be lowercase.)
 


### PR DESCRIPTION

<!--  
Thank you for submitting a pull request!  
Please delete the sections below that aren't pertinent to your PR  
and then fulfill the remaining checklist items before merging.  
-->

# tooling improvements

This PR updates the outdated link to the Agoric proposals explorer in the `README.md`. The original link (`https://bigdipper.live/agoric/proposals`) was no longer functional and has been replaced with the working link: [`https://agoric.explorers.guru/proposals`](https://agoric.explorers.guru/proposals).

## image building process

This change only affects documentation. It does not impact the image building process or the behavior of any other repos.

## @agoric/synthetic-chain library

No changes made to the library or its consumers.

* [x] CI is expected to pass as this is a documentation-only update.

re-open #250