### PR TITLE
fix(ci): Move snapshot bucket overwrite permission to vm

### DIFF
--- a/.github/workflows/trigger-mainfork-snapshot.yaml
+++ b/.github/workflows/trigger-mainfork-snapshot.yaml
@@ -1,5 +1,4 @@
 env:
-  BUCKET_NAME: 'agoric-snapshots-public'
   PROJECT_ID: 60745596728
 
 jobs:
@@ -75,11 +74,6 @@ jobs:
               exit 1
             fi
 
-            gsutil rm \
-              -a \
-              -f \
-              "gs://${{ env.BUCKET_NAME }}/mainfork-snapshots/keyring-test.tar.gz" \
-              "gs://${{ env.BUCKET_NAME }}/mainfork-snapshots/priv_validator_state.json"
             IMAGE_TAG="$IMAGE_TAG" ./mainfork-snapshot.sh
           fi
         working-directory: scripts


### PR DESCRIPTION
## Description
This PR fixes the case of failing [Create Mainfork Snapshot](https://github.com/Agoric/agoric-3-proposals/actions/runs/15273907233/job/42955598280) build as the `gsutil` command fails in case the files to be deleted are not found
This step was added because the service account used in [mainfork-snapshot.sh](https://github.com/Agoric/agoric-3-proposals/blob/main/scripts/mainfork-snapshot.sh) script only had object creation access so it couldn't ovewrite an existing file. The service account in question is now granted that permission so the deletion step in the Github Action is no longer needed
The permissions can be viewed using
```
gcloud storage buckets get-iam-policy "gs://agoric-snapshots-public"
```