### PR TITLE
ci(test-package): split into ranges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,14 @@ name: Proposal tests
 # and clicking "Run workflow", specifying this branch.
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
+    inputs:
+      from_scratch:
+        description: 'Rebuild all proposals from scratch'
+        required: false
+        default: false
+        type: boolean
   merge_group:
   push:
     branches: [main]
@@ -28,10 +35,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   test-package:
@@ -46,6 +49,7 @@ jobs:
 
       - name: Install deps
         run: |
+          set -e
           # Enable corepack for packageManager config
           corepack enable || sudo corepack enable
           yarn install
@@ -61,114 +65,111 @@ jobs:
         run: yarn test
         working-directory: packages/synthetic-chain
 
-  # see https://docs.docker.com/build/ci/github-actions/test-before-push/
-  test-proposals:
-    permissions:
-      # allow issuing OIDC tokens for this workflow run
-      id-token: write
-      # allow at least reading the repo contents, add other permissions if necessary
-      contents: read
-      # to push the resulting images
-      packages: write
-    runs-on: 'depot-ubuntu-22.04-16'
+  from-scratch:
+    runs-on: ubuntu-latest
+    outputs:
+      from-scratch: ${{ steps.from_scratch.outputs.from_scratch }}
     steps:
-      - name: free up disk space
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get changed packages
+        id: git_diff
+        uses: technote-space/get-diff-action@v6.1.2
+        with:
+          PATTERNS: |
+            packages/**/*.json
+            packages/**/.hcl
+            packages/**/*.js
+            packages/**/*.mjs
+            packages/**/*.cjs
+            packages/**/*.ts
+            packages/**/*.mts
+            packages/**/*.cts
+      - name: Set user's choice with label
+        id: user_from_scratch
+        env:
+          INPUT: ${{ inputs.from_scratch }}
+          FORCE: ${{ contains(github.event.pull_request.labels.*.name, 'force:from-scratch') && 'true' || 'false' }}
+          BYPASS: ${{ contains(github.event.pull_request.labels.*.name, 'bypass:from-scratch') && 'true' || 'false' }}
         run: |
-          # Workaround to provide additional free space for testing.
-          #   https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          # If this turns out not to be enough, maybe look instead at
-          #   https://github.com/actions/runner-images/issues/2840#issuecomment-1540506686
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          echo "=== After cleanup:"
-          df -h
+          set -ex
+          if [[ "$INPUT" == true ]]; then
+            echo "choice=true" >> $GITHUB_OUTPUT
+          elif [[ "$FORCE" == true ]]; then
+            echo "choice=true" >> $GITHUB_OUTPUT
+          elif [[ "$BYPASS" == true ]]; then
+            echo "choice=false" >> $GITHUB_OUTPUT
+          else
+            echo "choice=none" >> $GITHUB_OUTPUT
+          fi
+      - name: Set from_scratch flag
+        id: from_scratch
+        env:
+          USER_CHOICE: ${{ steps.user_from_scratch.outputs.choice }}
+          PACKAGES_CHANGED: ${{ steps.git_diff.outputs.diff && 'true' || 'false' }}
+        run: |
+          set -ex
+          if [ "$PACKAGES_CHANGED" == true ] && [ "$USER_CHOICE" == none ]; then
+            echo "packages source changed; you must choose between force:from-scratch or bypass:from-scratch"
+            exit 1
+          elif [ "$USER_CHOICE" == true ]; then
+            echo "from_scratch=true" >> $GITHUB_OUTPUT
+          else
+            echo "from_scratch=false" >> $GITHUB_OUTPUT
+          fi
 
+  make-ranges:
+    needs: from-scratch
+    runs-on: ubuntu-latest
+    outputs:
+      ranges: ${{ steps.make-ranges.outputs.ranges }}
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: depot/setup-action@v1
-        with:
-          oidc: true # to set DEPOT_TOKEN for later steps
-
-      # make Docker's CLI use depot to build
-      - run: depot configure-docker
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        # see https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ${{ env.REGISTRY }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Install deps
         run: |
+          set -e
           # Enable corepack for packageManager config
           corepack enable || sudo corepack enable
           yarn install
-
-      - name: Prepare Docker config
-        run: |
           yarn build-cli
-          # prepare files for bake-action
-          yarn synthetic-chain prepare-build
 
-      # Verify that all "use" images build across platforms.
-      - name: Build proposal "use" images
-        uses: depot/bake-action@v1
-        with:
-          files: |
-            ./docker-bake.json
-            ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
-          targets: use
+      - name: Decide how to batch the ranges
+        id: make-ranges
+        env:
+          IS_PR: ${{ github.event_name == 'pull_request'}}
+          FROM_SCRATCH: ${{ needs.from-scratch.outputs.from-scratch}}
+        run: |
+          set -ex
+          opts=
+          if [ "$FROM_SCRATCH" == true ]; then
+            opts="$opts --rebuild"
+          fi
+          if [ "$IS_PR" == true ]; then
+            opts="$opts --no-push"
+          fi
+          echo "ranges=$(yarn synthetic-chain make-ranges$opts)" >> "$GITHUB_OUTPUT"
 
-      # Verify that proposals' tests pass.
-      # Note this builds each proposal testing image sequentially. It does that so it can delete the image
-      # after it passees, freeing up disk space.
-      - name: Build and run proposal tests
-        run: yarn test
+  test-proposals:
+    needs: make-ranges
+    strategy:
+      fail-fast: true
+      # XXX We need to split the proposals and build each range sequentially
+      # to avoid overwhelming the Depot builder with too much parallelism.
+      max-parallel: 1
+      matrix:
+        range: ${{ fromJson(needs.make-ranges.outputs.ranges) }}
+    uses: ./.github/workflows/docker-proposals.yml
+    with:
+      range: ${{ matrix.range }}
+      image_name: ${{ github.repository }}
+    secrets: inherit
 
-      # Push the images if the tests pass and this is not a PR
-      - name: Push proposal "use" images
-        # If we pushed from PRs, each one would overwrite main's (e.g. use-upgrade-8)
-        # To push PR "use" images we'll need to qualify the tag (e.g. use-upgrade-8-pr-2).
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: depot/bake-action@v1
-        with:
-          files: |
-            ./docker-bake.json
-            ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
-          targets: use
-          push: true
-
-      # Just like the "use" image above but has to begin after that ends
-      # because the "build" here is merely to retag the latest "use" image.
-      # We could do this with imagetools but this lets use keep the tagging logic
-      # in Bake instead of mixed into CI. This step should do hardly any building
-      # because its FROM image was just built above.
-      - name: Push "latest" image
-        # Same reason as for "use" images
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: depot/bake-action@v1
-        with:
-          files: |
-            ./docker-bake.json
-            ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
-          targets: latest
-          push: true
-
+  notify-on-failure:
+    needs: [test-package, test-proposals]
+    runs-on: ubuntu-latest
+    steps:
       - name: notify on failure
         if: failure() && github.event_name != 'pull_request'
         uses: ./.github/actions/notify-status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       range: ${{ matrix.range }}
       image_name: ${{ github.repository }}
     secrets: inherit
-  
+
   test-proposals:
     needs: [test-proposals-ranges]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           fi
           echo "ranges=$(yarn synthetic-chain make-ranges$opts)" >> "$GITHUB_OUTPUT"
 
-  test-proposals:
+  test-proposals-ranges:
     needs: make-ranges
     strategy:
       fail-fast: true
@@ -165,6 +165,19 @@ jobs:
       range: ${{ matrix.range }}
       image_name: ${{ github.repository }}
     secrets: inherit
+  
+  test-proposals:
+    needs: [test-proposals-ranges]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check test-proposals-ranges result
+        run: |
+          echo "test-proposals-ranges result: ${{ needs.test-proposals-ranges.result }}"
+          if [ "${{ needs.test-proposals-ranges.result }}" != "success" ]; then
+            echo "Some proposals failed!"
+            exit 1
+          fi
 
   notify-on-failure:
     needs: [test-package, test-proposals]

--- a/.github/workflows/docker-proposals.yml
+++ b/.github/workflows/docker-proposals.yml
@@ -136,8 +136,8 @@ jobs:
           # prepare files for bake-action
           yarn synthetic-chain prepare-build$BUILD_FLAGS
 
-      # Verify that all "use" and "prepare" images build across platforms.
-      - name: Build proposal "use" and "prepare" images
+      # Verify that all "use" images build across platforms.
+      - name: Build proposal "use" images
         uses: depot/bake-action@v1
         with:
           files: |

--- a/.github/workflows/docker-proposals.yml
+++ b/.github/workflows/docker-proposals.yml
@@ -1,0 +1,186 @@
+name: Docker Build Proposal Range
+
+on:
+  workflow_dispatch:
+    # XXX: Would be great to use a YAML anchor for shared inputs, but they are
+    # not supported in Actions.
+    inputs:
+      range:
+        description: '"start/end" proposal ranges'
+        required: false
+        default: ''
+        type: string
+      registry:
+        description: 'Container registry'
+        required: false
+        default: 'ghcr.io'
+        type: string
+      image_name:
+        description: 'Container image name'
+        required: false
+        default: agoric/agoric-3-proposals # XXX: '${{ github.repository }}'
+        type: string
+  workflow_call:
+    # XXX: Would be great to use a YAML anchor for shared inputs, but they are
+    # not supported in Actions.
+    inputs:
+      range:
+        description: '"start/end" proposal ranges'
+        required: false
+        default: ''
+        type: string
+      registry:
+        description: 'Container registry'
+        required: false
+        default: 'ghcr.io'
+        type: string
+      image_name:
+        description: 'Container image name'
+        required: false
+        default: agoric/agoric-3-proposals # XXX: '${{ github.repository }}'
+        type: string
+
+jobs:
+  # see https://docs.docker.com/build/ci/github-actions/test-before-push/
+  test:
+    permissions:
+      # allow issuing OIDC tokens for this workflow run
+      id-token: write
+      # allow at least reading the repo contents, add other permissions if necessary
+      contents: read
+      # to push the resulting images
+      packages: write
+    runs-on: 'depot-ubuntu-22.04-16'
+
+    steps:
+      - name: Prepare build flags
+        id: flags
+        env:
+          RANGE: ${{ inputs.range }}
+        run: |
+          set -ex
+          build_flags=
+          # Split the range into start and stop proposals.
+          if [[ -z "$RANGE" ]]; then
+            echo "No range specified, building all."
+          # The range is expected to be in the form "start/stop" or "start/" or "/stop".
+          elif [[ "$RANGE" =~ ^([^/]*)/([^/]*)$ ]]; then
+            start="${BASH_REMATCH[1]}"
+            stop="${BASH_REMATCH[2]}"
+          else
+            echo "Invalid range format: '$RANGE'. Expected 'start/stop' or 'start/' or '/stop'."
+            exit 1
+          fi
+
+          test -z "$start" || build_flags="$build_flags --start=$start"
+          echo "start=$start" >> $GITHUB_OUTPUT
+
+          test -z "$stop" || build_flags="$build_flags --stop=$stop"
+          echo "stop=$stop" >> $GITHUB_OUTPUT
+
+          echo "Using build flags:$build_flags"
+          echo "build_flags=$build_flags" >> $GITHUB_OUTPUT
+
+      - name: free up disk space
+        run: |
+          # Workaround to provide additional free space for testing.
+          #   https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+          # If this turns out not to be enough, maybe look instead at
+          #   https://github.com/actions/runner-images/issues/2840#issuecomment-1540506686
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          echo "=== After cleanup:"
+          df -h
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: depot/setup-action@v1
+        with:
+          oidc: true # to set DEPOT_TOKEN for later steps
+
+      # make Docker's CLI use depot to build
+      - run: depot configure-docker
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        # see https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ inputs.registry }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image_name }}
+
+      - name: Install deps
+        run: |
+          # Enable corepack for packageManager config
+          corepack enable || sudo corepack enable
+          yarn install
+
+      - name: Prepare Docker config
+        env:
+          BUILD_FLAGS: ${{ steps.flags.outputs.build_flags }}
+        run: |
+          set -ex
+
+          yarn build-cli
+
+          # prepare files for bake-action
+          yarn synthetic-chain prepare-build$BUILD_FLAGS
+
+      # Verify that all "use" and "prepare" images build across platforms.
+      - name: Build proposal "use" and "prepare" images
+        uses: depot/bake-action@v1
+        with:
+          files: |
+            ./docker-bake.json
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: use
+
+      # Verify that proposals' tests pass.
+      # Note this builds each proposal testing image sequentially. It does that so it can delete the image
+      # after it passees, freeing up disk space.
+      - name: Build and run proposal tests
+        env:
+          BUILD_FLAGS: ${{ steps.flags.outputs.build_flags }}
+        run: yarn test$BUILD_FLAGS
+
+      # Push the images if the tests pass and this is not a PR
+      - name: Push proposal "use" images
+        # If we pushed from PRs, each one would overwrite main's (e.g. use-upgrade-8)
+        # To push PR "use" images we'll need to qualify the tag (e.g. use-upgrade-8-pr-2).
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: depot/bake-action@v1
+        with:
+          files: |
+            ./docker-bake.json
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: use
+          push: true
+
+      # Just like the "use" image above but has to begin after that ends
+      # because the "build" here is merely to retag the latest "use" image.
+      # We could do this with imagetools but this lets use keep the tagging logic
+      # in Bake instead of mixed into CI. This step should do hardly any building
+      # because its FROM image was just built above.
+      - name: Push "latest" image
+        # Same reason as for "use" images
+        if: ${{ github.event_name != 'pull_request' && !steps.flags.outputs.stop }}
+        uses: depot/bake-action@v1
+        with:
+          files: |
+            ./docker-bake.json
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: latest
+          push: true

--- a/packages/synthetic-chain/src/cli/cli.ts
+++ b/packages/synthetic-chain/src/cli/cli.ts
@@ -24,6 +24,7 @@ import { debugTestImage, runTestImage } from './run.js';
 
 const root = path.resolve('.');
 const buildConfig = readBuildConfig(root);
+const DEFAULT_START = (buildConfig.fromTag || '').replace(/^use-/, '');
 
 const { positionals, values } = parseArgs({
   options: {
@@ -33,7 +34,7 @@ const { positionals, values } = parseArgs({
     debug: { type: 'boolean' },
     rebuild: { type: 'boolean', default: false },
     'no-push': { type: 'boolean', default: false },
-    start: { type: 'string', default: buildConfig.fromTag || '' },
+    start: { type: 'string', default: DEFAULT_START },
     stop: { type: 'string', default: '' },
   },
   allowPositionals: true,

--- a/packages/synthetic-chain/src/cli/cli.ts
+++ b/packages/synthetic-chain/src/cli/cli.ts
@@ -14,32 +14,42 @@ import {
 } from './build.js';
 import { writeBakefileProposals, writeDockerfile } from './dockerfileGen.js';
 import { runDoctor } from './doctor.js';
-import { imageNameForProposal, readProposals } from './proposals.js';
+import {
+  imageNameForProposal,
+  readProposals,
+  getProposalRange,
+  type ProposalRange,
+} from './proposals.js';
 import { debugTestImage, runTestImage } from './run.js';
+
+const root = path.resolve('.');
+const buildConfig = readBuildConfig(root);
 
 const { positionals, values } = parseArgs({
   options: {
+    all: { type: 'boolean', default: false },
     match: { short: 'm', type: 'string' },
     dry: { type: 'boolean' },
     debug: { type: 'boolean' },
+    rebuild: { type: 'boolean', default: false },
+    'no-push': { type: 'boolean', default: false },
+    start: { type: 'string', default: buildConfig.fromTag || '' },
+    stop: { type: 'string', default: '' },
   },
   allowPositionals: true,
 });
 
-const root = path.resolve('.');
-const buildConfig = readBuildConfig(root);
-const allProposals = readProposals(root);
-
-const { match } = values;
-const proposals = match
-  ? allProposals.filter(p => p.path.includes(match))
-  : allProposals;
+const range = getProposalRange(readProposals(root), values);
 
 const [cmd] = positionals;
 
 // TODO consider a lib like Commander for auto-gen help
 const USAGE = `USAGE:
 prepare-build   - generate Docker build configs
+
+make-ranges     - split proposals into required ranges
+  [--rebuild]   - rebuild all the proposals
+  [--no-push]   - error if any images would need to be pushed
 
 build           - build the synthetic-chain "use" images
   [--dry]       - print the config without building images
@@ -66,16 +76,16 @@ Instead use a builder that supports multiplatform such as depot.dev.
 /**
  * Put into places files that building depends upon.
  */
-const prepareDockerBuild = () => {
+const prepareDockerBuild = (range: ProposalRange) => {
   const cliPath = new URL(import.meta.url).pathname;
   const publicDir = path.resolve(cliPath, '..', '..');
   // copy and generate files of the build context that aren't in the build contents
   execSync(`cp -r ${path.resolve(publicDir, 'docker-bake.hcl')} .`);
-  writeDockerfile(allProposals, buildConfig.fromTag);
-  writeBakefileProposals(allProposals, buildConfig.platforms);
+  writeDockerfile(range);
+  writeBakefileProposals(range, buildConfig.platforms);
   // copy and generate files to include in the build
   execSync(`cp -r ${path.resolve(publicDir, 'upgrade-test-scripts')} .`);
-  buildProposalSubmissions(proposals);
+  buildProposalSubmissions(range.proposals);
   // set timestamp of build content to zero to avoid invalidating the build cache
   // (change in contents will still invalidate)
   execSync(
@@ -84,11 +94,64 @@ const prepareDockerBuild = () => {
 };
 
 switch (cmd) {
+  case 'make-ranges': {
+    const { all, rebuild, 'no-push': noPush } = values;
+    const ranges: string[] = [];
+    let lastName: string | undefined;
+    let rebuildRest = rebuild;
+    const someProposals = range.proposals;
+    const lastUpgrade = range.proposals.findLastIndex(
+      p => p.type === 'Software Upgrade Proposal',
+    );
+    const tail = lastUpgrade < 0 ? 0 : lastUpgrade;
+    for (let i = 0; i < someProposals.length; i++) {
+      const proposal = someProposals[i];
+      const name = proposal.proposalName;
+      if (!rebuildRest) {
+        const image = imageNameForProposal(proposal, 'use');
+        if (
+          i < tail &&
+          (all || proposal.type === 'Software Upgrade Proposal')
+        ) {
+          console.warn(
+            `[${i + 1}/${someProposals.length}] Checking ${image.name}...`,
+          );
+          try {
+            execSync(`docker manifest inspect ${JSON.stringify(image.name)}`, {
+              stdio: 'ignore',
+            });
+            console.warn(`Skipping ${name} because it is already pushed`);
+            lastName = name;
+            continue;
+          } catch (e) {}
+        }
+        if (i >= tail || !noPush) {
+          console.warn(`Rebuilding ${name} and the rest...`);
+          rebuildRest = true;
+        } else if (noPush) {
+          console.error(`${name} not found, needs to be pushed`);
+          process.exit(1);
+        }
+      }
+
+      if (lastName !== undefined) {
+        ranges.push(`${lastName}/${name}`);
+      }
+      lastName = name;
+    }
+
+    if (lastName !== undefined) {
+      ranges.push(`${lastName}/`);
+    }
+
+    console.log(JSON.stringify(ranges));
+    break;
+  }
   case 'prepare-build':
-    prepareDockerBuild();
+    prepareDockerBuild(range);
     break;
   case 'build': {
-    prepareDockerBuild();
+    prepareDockerBuild(range);
     // do not encapsulate running Depot. It's a special case which the user should understand.
     if (buildConfig.platforms) {
       console.error(EXPLAIN_MULTIPLATFORM);
@@ -100,20 +163,19 @@ switch (cmd) {
   case 'test':
     // Always rebuild all test images to keep it simple. With the "use" stages
     // cached, these are pretty fast building doesn't run agd.
-    prepareDockerBuild();
+    prepareDockerBuild(range);
 
     if (values.debug) {
-      assert(match, '--debug requires -m');
-      assert(proposals.length > 0, 'no proposals match');
-      assert(proposals.length === 1, 'too many proposals match');
-      const proposal = proposals[0];
+      assert(values.match, '--debug requires -m');
+      assert(range.proposalsToTest.length === 1, 'too many proposals match');
+      const proposal = range.proposalsToTest[0];
       console.log(chalk.yellow.bold(`Debugging ${proposal.proposalName}`));
       bakeTarget(imageNameForProposal(proposal, 'test').target, values.dry);
       debugTestImage(proposal);
       // don't bother to delete the test image because there's just one
       // and the user probably wants to run it again.
     } else {
-      for (const proposal of proposals) {
+      for (const proposal of range.proposalsToTest) {
         console.log(chalk.cyan.bold(`Testing ${proposal.proposalName}`));
         const image = imageNameForProposal(proposal, 'test');
         bakeTarget(image.target, values.dry);
@@ -127,8 +189,9 @@ switch (cmd) {
     }
     break;
   case 'doctor':
-    runDoctor(allProposals);
+    runDoctor(range.allProposals);
     break;
   default:
     console.log(USAGE);
+    process.exit(1);
 }

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -4,6 +4,7 @@ import {
   encodeUpgradeInfo,
   imageNameForProposal,
   isPassed,
+  ProposalRange,
   type CoreEvalPackage,
   type ParameterChangePackage,
   type ProposalInfo,
@@ -47,10 +48,10 @@ RUN /usr/src/upgrade-test-scripts/run_prepare_zero.sh
    * Resume from state of an existing image.
    * Creates a "use" stage upon which a PREPARE or EVAL can stack.
    */
-  RESUME(fromTag: string) {
+  RESUME(proposalName: string) {
     return `
 ## RESUME
-FROM ghcr.io/agoric/agoric-3-proposals:${fromTag} as use-${fromTag}
+FROM ghcr.io/agoric/agoric-3-proposals:use-${proposalName} as use-${proposalName}
 `;
   },
 
@@ -241,7 +242,7 @@ ENTRYPOINT ./run_test.sh ${path}
     // Some background: https://github.com/moby/moby/issues/34715
     const useImage = imageNameForProposal(lastProposal, 'use').name;
     return `
-# LAST
+## LAST
 FROM ${useImage} as latest
 `;
   },
@@ -260,7 +261,7 @@ export const createCopyCommand = (
   ].join(' ');
 
 export function writeBakefileProposals(
-  allProposals: ProposalInfo[],
+  range: ProposalRange,
   platforms?: Platform[],
 ) {
   const json = {
@@ -269,37 +270,28 @@ export function writeBakefileProposals(
         default: platforms || null,
       },
       PROPOSALS: {
-        default: allProposals.map(p => p.proposalName),
+        default: range.proposals.map(p => p.proposalName),
+      },
+      UPGRADE_PROPOSALS: {
+        default: range.proposals
+          .filter(p => p.type === 'Software Upgrade Proposal')
+          .map(p => p.proposalName),
       },
     },
   };
   fs.writeFileSync('docker-bake.json', JSON.stringify(json, null, 2));
 }
 
-export function writeDockerfile(
-  allProposals: ProposalInfo[],
-  fromTag?: string | null,
-) {
+export function writeDockerfile(range: ProposalRange) {
   // Each stage tests something about the left argument and prepare an upgrade to the right side (by passing the proposal and halting the chain.)
   // The upgrade doesn't happen until the next stage begins executing.
   const blocks: string[] = [syntaxPragma];
 
-  let previousProposal: ProposalInfo | null = null;
-
-  // appending to a previous image, so set up the 'use' stage
-  if (fromTag) {
-    blocks.push(stage.RESUME(fromTag));
-    // define a previous proposal that matches what later stages expect
-    previousProposal = {
-      proposalName: fromTag,
-      proposalIdentifier: fromTag,
-      // XXX these are bogus
-      path: '.',
-      type: '/agoric.swingset.CoreEvalProposal',
-      source: 'subdir',
-    };
+  let previousProposal = range.previousProposal;
+  if (previousProposal) {
+    blocks.push(stage.RESUME(previousProposal.proposalName));
   }
-  for (const proposal of allProposals) {
+  for (const proposal of range.proposals) {
     // UNTIL region support https://github.com/microsoft/vscode-docker/issues/230
     blocks.push(
       `#----------------\n# ${proposal.proposalName}\n#----------------`,
@@ -311,7 +303,7 @@ export function writeDockerfile(
         blocks.push(stage.EVAL(proposal, previousProposal!));
         break;
       case 'Software Upgrade Proposal':
-        // handle the first proposal specially
+        // handle the first proposal of the chain specially
         if (previousProposal) {
           blocks.push(stage.PREPARE(proposal, previousProposal));
         } else {
@@ -333,10 +325,13 @@ export function writeDockerfile(
     blocks.push(stage.TEST(proposal));
     previousProposal = proposal;
   }
-  // If one of the proposals is a passed proposal, make the latest one the default entrypoint
-  const lastPassed = allProposals.findLast(isPassed);
-  if (lastPassed) {
-    blocks.push(stage.LAST(lastPassed));
+
+  if (range.lastProposalIsLatest) {
+    // If one of the proposals is a passed proposal, make the latest one the default entrypoint
+    const lastPassed = range.proposals.findLast(isPassed);
+    if (lastPassed) {
+      blocks.push(stage.LAST(lastPassed));
+    }
   }
 
   const contents = blocks.join('\n');

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -303,10 +303,10 @@ export function writeDockerfile(range: ProposalRange) {
         blocks.push(stage.EVAL(proposal, previousProposal!));
         break;
       case 'Software Upgrade Proposal':
-        // handle the first proposal of the chain specially
         if (previousProposal) {
           blocks.push(stage.PREPARE(proposal, previousProposal));
         } else {
+          // handle the first proposal of the chain specially
           blocks.push(
             stage.PREPARE_ZERO(proposal.proposalName, proposal.planName),
           );

--- a/packages/synthetic-chain/src/cli/proposals.ts
+++ b/packages/synthetic-chain/src/cli/proposals.ts
@@ -25,7 +25,6 @@ export function getProposalRange(
 ): ProposalRange {
   let failures = '';
   let sep = '';
-  const startFrom0 = !start;
 
   const startIndex = allProposals.findIndex(p => p.proposalName === start);
   if (start && startIndex < 0) {
@@ -39,8 +38,13 @@ export function getProposalRange(
     sep = ', ';
   }
 
-  const sliceStart = startIndex < 0 ? 0 : startIndex;
-  const sliceEnd = stopIndex < 0 ? allProposals.length : stopIndex;
+  if (failures) {
+    console.error(`Getting proposal range:`, { start, stop });
+    throw new Error(`Invalid proposal range: ${failures}`);
+  }
+
+  const sliceStart = start ? startIndex : 0;
+  const sliceEnd = stop ? stopIndex : allProposals.length;
   const someProposals = allProposals.slice(sliceStart, sliceEnd);
   const proposals = match
     ? someProposals.filter(p => p.proposalName.includes(match))


### PR DESCRIPTION
## @agoric/synthetic-chain library

We currently build all the layered proposal states, then run all the tests on them, and if both of those pass, publish all the unpublished states.  Aggressive caching with depot makes this work, but it overwhelms Depot with all the proposal interdependencies and the huge parallel build
This PR circumvents this with a matrix job that specifies a list of proposal ranges and the build/test/publish of each range is parallelized (as before), but the ranges are performed in series