### PR TITLE
fix handling of build config fromTag

### DIFF
--- a/.changeset/thin-ears-share.md
+++ b/.changeset/thin-ears-share.md
@@ -1,0 +1,7 @@
+---
+'@agoric/synthetic-chain': patch
+---
+
+fix handling of build config fromTag
+
+`fromTag` is meant to indicate an image to start from that isn't available in the local set of proposals.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           IS_PR: ${{ github.event_name == 'pull_request'}}
           FROM_SCRATCH: ${{ needs.from-scratch.outputs.from-scratch}}
         run: |
-          set -ex
+          set -ex -o pipefail
           opts=
           if [ "$FROM_SCRATCH" == true ]; then
             opts="$opts --rebuild"
@@ -149,7 +149,8 @@ jobs:
           if [ "$IS_PR" == true ]; then
             opts="$opts --no-push"
           fi
-          echo "ranges=$(yarn synthetic-chain make-ranges$opts)" >> "$GITHUB_OUTPUT"
+          ranges=$(yarn synthetic-chain make-ranges$opts)
+          echo "ranges=$ranges" >> "$GITHUB_OUTPUT"
 
   test-proposals-ranges:
     needs: make-ranges

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,17 +168,37 @@ jobs:
     secrets: inherit
 
   test-proposals:
-    needs: [test-proposals-ranges]
+    needs: [test-proposals-ranges, make-ranges]
     runs-on: ubuntu-latest
-    if: always()
+    if: >-
+      always() &&
+      !contains(github.event.pull_request.labels.*.name, 'bypass:from-scratch')
     steps:
       - name: Check test-proposals-ranges result
+        env:
+          TEST_PROPOSALS_RESULT: ${{ needs.test-proposals-ranges.result }}
+          MAKE_RANGES_RESULT: ${{ needs.make-ranges.result }}
         run: |
-          echo "test-proposals-ranges result: ${{ needs.test-proposals-ranges.result }}"
-          if [ "${{ needs.test-proposals-ranges.result }}" != "success" ]; then
-            echo "Some proposals failed!"
-            exit 1
-          fi
+
+          echo "test-proposals-ranges result: $TEST_PROPOSALS_RESULT"
+          case "$TEST_PROPOSALS_RESULT" in
+            success | skipped)
+              ;;
+            *)
+              echo "Some proposals failed!"
+              exit 1
+              ;;
+          esac
+
+          echo "make-ranges result: $MAKE_RANGES_RESULT"
+          case "$MAKE_RANGES_RESULT" in
+            success | skipped)
+              ;;
+            *)
+              echo "Make ranges failed!"
+              exit 1
+              ;;
+          esac
 
   notify-on-failure:
     needs: [test-package, test-proposals]

--- a/packages/synthetic-chain/src/cli/cli.ts
+++ b/packages/synthetic-chain/src/cli/cli.ts
@@ -24,7 +24,6 @@ import { debugTestImage, runTestImage } from './run.js';
 
 const root = path.resolve('.');
 const buildConfig = readBuildConfig(root);
-const DEFAULT_START = (buildConfig.fromTag || '').replace(/^use-/, '');
 
 const { positionals, values } = parseArgs({
   options: {
@@ -34,13 +33,13 @@ const { positionals, values } = parseArgs({
     debug: { type: 'boolean' },
     rebuild: { type: 'boolean', default: false },
     'no-push': { type: 'boolean', default: false },
-    start: { type: 'string', default: DEFAULT_START },
+    start: { type: 'string', default: '' },
     stop: { type: 'string', default: '' },
   },
   allowPositionals: true,
 });
 
-const range = getProposalRange(readProposals(root), values);
+const range = getProposalRange(readProposals(root), buildConfig, values);
 
 const [cmd] = positionals;
 


### PR DESCRIPTION
## @agoric/synthetic-chain library

Follow-up to #262 to handle `fromTag` which is meant to indicate an image to start from that isn't available in the local set of proposals.

## CI

Fix CI to better honor `bypass:from-scratch` 