### PR TITLE
ci: lower case image tag when pushing

### DIFF
--- a/.github/workflows/docker-proposals.yml
+++ b/.github/workflows/docker-proposals.yml
@@ -248,6 +248,7 @@ jobs:
           PROJECT_ID: ${{ needs.build.outputs.project-id }}
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs.image_name }}
+        # ,, to lowercase because Agoric org is uppercase and Depot requires lowercase
         run: depot push --project $PROJECT_ID --tag "$REGISTRY/${IMAGE_NAME,,}:$TARGET" --target $TARGET $BUILD_ID
 
       # XXX: depot.dev is configured with a 1-day retention for registry images


### PR DESCRIPTION
## image building process

Follow-up to #283. `image_name` was set as `${{ github.repository }}`. Unfortunately our org name has an upper case in `Agoric`, and `depot push` does not automatically make it lowercase, so do that ourselves

Wasn't caught in the manual run since I relied on the hard-coded default which didn't reflect the actual value passed, nor in PR checks since push is skipped there.