### PR TITLE
fix(synthetic-chain): latest builds from multi-stage target

### DIFF
--- a/.changeset/silly-seas-read.md
+++ b/.changeset/silly-seas-read.md
@@ -1,0 +1,5 @@
+---
+'@agoric/synthetic-chain': patch
+---
+
+build latest from the multi-stage build target

--- a/packages/synthetic-chain/src/cli/dockerfileGen.ts
+++ b/packages/synthetic-chain/src/cli/dockerfileGen.ts
@@ -236,14 +236,9 @@ ENTRYPOINT ./run_test.sh ${path}
    * The last target in the file, for untargeted `docker build`
    */
   LAST(lastProposal: ProposalInfo) {
-    // Assumes the 'use' image is built and tagged.
-    // This isn't necessary for a multi-stage build, but without it CI
-    // rebuilds the last "use" image during the "default" image step
-    // Some background: https://github.com/moby/moby/issues/34715
-    const useImage = imageNameForProposal(lastProposal, 'use').name;
     return `
 ## LAST
-FROM ${useImage} as latest
+FROM use-${lastProposal.proposalName} as latest
 `;
   },
 };


### PR DESCRIPTION
Refs #286

## @agoric/synthetic-chain library

This reverts https://github.com/Agoric/agoric-3-proposals/commit/9285e9bbf288df003812c7c9e89bef87c812e016. Since then we've change the building process in https://github.com/Agoric/agoric-3-proposals/pull/283 to build all targets once, and then push the built targets after tests pass.

Because of that, we were actually pushing the wrong image for `latest`, attempting to use a previously published one instead of the use target from the build. That results in an error when adding a new latest proposal.