### PR TITLE
fix: Mainfork snaphot extraction flow should support any image tag

### DIFF
--- a/.github/workflows/trigger-mainfork-snapshot.yaml
+++ b/.github/workflows/trigger-mainfork-snapshot.yaml
@@ -67,7 +67,7 @@ jobs:
           then
             IMAGE_TAG="$(
               curl --silent "$FOLLOWER_HOMEPAGE" | \
-              sed --regexp-extended --silent 's|.*ghcr.io/agoric/agoric-sdk:([0-9]+).*|\1|p'
+              sed --regexp-extended --silent 's|.*ghcr.io/agoric/agoric-sdk:(\S+).*|\1|p'
             )"
 
             if test -z "$IMAGE_TAG"


### PR DESCRIPTION
## Description

Mainfork snapshot trigger flow expects the image tag to be numeric which is not always true


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve image tag extraction handling from upstream sources.

---

**Note:** This release contains infrastructure and tooling updates with no direct impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->