### PR TITLE
feat(synthetic-chain): set `$PUBLISHED_RPC_ENDPOINT` for `test.sh`

### DIFF
--- a/.changeset/fail-balloons-tease.md
+++ b/.changeset/fail-balloons-tease.md
@@ -1,0 +1,8 @@
+---
+'@agoric/synthetic-chain': patch
+---
+
+feat(synthetic-chain): set `$PUBLISHED_RPC_ENDPOINT` for `test.sh`
+
+Allow `before-test-run.sh` and `after-test-run.sh` not to hardcode the chain's
+`<host>:<port>` RPC endpoint.

--- a/packages/synthetic-chain/src/cli/run.ts
+++ b/packages/synthetic-chain/src/cli/run.ts
@@ -4,6 +4,9 @@ import { resolve as resolvePath } from 'node:path';
 import { fileSync as createTempFile } from 'tmp';
 import { type ProposalInfo, imageNameForProposal } from './proposals.js';
 
+/** Use 26647 to avoid conflicts with 26657. */
+const DEFAULT_PUBLISHED_RPC_ENDPOINT = '127.0.0.1:26647';
+
 const createMessageFile = (proposal: ProposalInfo) =>
   createTempFile({ prefix: proposal.proposalName });
 
@@ -50,10 +53,12 @@ export const runTestImage = ({
   extraDockerArgs = [],
   proposal,
   removeContainerOnExit = true,
+  publishedRpcEndpoint = DEFAULT_PUBLISHED_RPC_ENDPOINT,
 }: {
   extraDockerArgs?: Array<string>;
   proposal: ProposalInfo;
   removeContainerOnExit?: boolean;
+  publishedRpcEndpoint?: string;
 }) => {
   const { name: messageFilePath, removeCallback: removeTempFileCallback } =
     createMessageFile(proposal);
@@ -66,6 +71,7 @@ export const runTestImage = ({
   try {
     executeHostScriptIfPresent(
       {
+        PUBLISHED_RPC_ENDPOINT: publishedRpcEndpoint,
         MESSAGE_FILE_PATH: messageFilePath,
       },
       proposal,
@@ -79,14 +85,14 @@ export const runTestImage = ({
         'run',
         '--env',
         `MESSAGE_FILE_PATH=${containerFilePath}`,
-        // We need to publish the RPC port to allow local test scripts
-        // to interact with the chain running in the container. The
-        // old gymnastics of attempting to read an IP address from
-        // the container weren't portable to Docker running in a VM.
-        '--publish',
-        '127.0.0.1:26657:26657',
         '--mount',
         `source=${messageFilePath},target=${containerFilePath},type=bind`,
+        // We need to publish the RPC port to allow before-test-run.sh and
+        // after-test-run.sh to interact with the chain running in the
+        // container. The old gymnastics of attempting to read an IP address
+        // from the container weren't portable to Docker running in a VM.
+        '--publish',
+        `${publishedRpcEndpoint}:26657`,
         ...(removeContainerOnExit ? ['--rm'] : []),
         ...propagateSlogfile(process.env),
         ...extraDockerArgs,
@@ -97,6 +103,7 @@ export const runTestImage = ({
 
     executeHostScriptIfPresent(
       {
+        PUBLISHED_RPC_ENDPOINT: publishedRpcEndpoint,
         MESSAGE_FILE_PATH: messageFilePath,
       },
       proposal,
@@ -141,7 +148,8 @@ export const debugTestImage = (proposal: ProposalInfo) => {
       '127.0.0.1:1317:1317',
       '--publish',
       '127.0.0.1:9090:9090',
-      // 127.0.0.1:26657 is already published directly by `runTestImage`
+      '--publish',
+      '127.0.0.1:26657:26657',
       '--tty',
     ],
     proposal,


### PR DESCRIPTION
In this PR, both `before-test-run.sh` and `after-test-run.sh` host scripts can avoid hardcoding the chain's RPC port, and instead use the value of `$PUBLISHED_RPC_ENDPOINT` which is set by `run.ts` when it starts the synthetic chain.

Will be published immediately by @michaelfig for inclusion in `agoric-upgrade-23-rc1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RPC port publishing for synthetic chain test images is now configurable, allowing custom host address/port mappings.
  * Test runner exposes the configured RPC endpoint to pre/post-test scripts via an environment variable so those scripts use the chosen mapping.

* **Chores**
  * Added a changeset entry to publish a patch release for this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->