### PR TITLE
synthetic-chain Node.js v24 compatibility

### DIFF
--- a/.changeset/rare-lands-walk.md
+++ b/.changeset/rare-lands-walk.md
@@ -1,0 +1,5 @@
+---
+'@agoric/synthetic-chain': patch
+---
+
+Ensure compatibility with Node.js v24

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,6 +6,14 @@ inputs:
     description: 'The path to yarn.lock files for setup-node to cache with'
     required: false
     default: ''
+  node-version:
+    description: 'The Node.js version to set up'
+    required: false
+    # TODO: Due to a circular dependency between synthetic-chain and Agoric SDK, CI can't
+    # use Node.js 24 until we can rely on a version of Agoric SDK that supports it, which
+    # means synthetic-chain needs to publish a compatible version first.
+    # default: '24'
+    default: '22'
 
 runs:
   using: composite
@@ -14,7 +22,7 @@ runs:
     # https://github.com/actions/setup-node/issues/899#issuecomment-1828798029.
     - uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: ${{ inputs.node-version }}
 
     # Before setup-node because that action tries to discover the cache directory.
     # See https://github.com/actions/setup-node/issues/480#issuecomment-1915448139
@@ -26,6 +34,6 @@ runs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: ${{ inputs.node-version }}
         cache: yarn
         cache-dependency-path: ${{ inputs.lock-path }}

--- a/packages/synthetic-chain/src/cli/proposals.ts
+++ b/packages/synthetic-chain/src/cli/proposals.ts
@@ -217,9 +217,8 @@ export function readProposals(proposalsParent: string): ProposalInfo[] {
   const proposalPaths = fs
     .readdirSync(proposalsDir, { withFileTypes: true })
     .filter(dirent => {
-      assert('path' in dirent, 'missing path in dirent added in Node 18.17');
       const hasPackageJson = fs.existsSync(
-        path.join(dirent.path, dirent.name, 'package.json'),
+        path.join(proposalsDir, dirent.name, 'package.json'),
       );
       if (!hasPackageJson) {
         console.warn(


### PR DESCRIPTION
## Summary
- replace use of removed `Dirent.path` with the known proposals directory when reading proposal package metadata
- add a patch changeset for `@agoric/synthetic-chain`
- leave the shared CI setup on Node.js 22 for now, with TODO comments explaining that CI cannot move to Node.js 24 until the Agoric SDK dependency cycle is resolved

## Validation
- `yarn lint`: passed

Co-authored-by: Codex <codex@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed proposal directory scanning to correctly identify valid proposal packages.

* **Chores**
  * Prepared a patch release for `synthetic-chain`, including updated guidance for Node.js v24 compatibility.
  * Updated CI configuration to allow selecting the Node.js version via an input (defaulting to v22), and documented current limitations around Node.js v24 usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->